### PR TITLE
Add AWS_EC2_EIP Tags properties

### DIFF
--- a/schema/spec-2.15.0.json
+++ b/schema/spec-2.15.0.json
@@ -5918,6 +5918,10 @@
           "PublicIpv4Pool" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-eip.html#cfn-ec2-eip-publicipv4pool",
             "$ref" : "#/definitions/Expression"
+          },
+          "Tags" : {
+            "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-eip.html#cfn-ec2-eip-tags",
+            "$ref" : "#/definitions/Expression"
           }
         },
         "additionalProperties" : false


### PR DESCRIPTION
Added tagging for ElasicIP properties. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
