### PR TITLE
CloudFormation Template Schema 11.6.0

### DIFF
--- a/schema/all-spec.json
+++ b/schema/all-spec.json
@@ -6271,6 +6271,36 @@
     "required" : [ "Type", "Properties" ],
     "additionalProperties" : false
   },
+  "AWS_CodeGuruProfiler_ProfilingGroup" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codeguruprofiler-profilinggroup.html",
+    "properties" : {
+      "Type" : {
+        "description" : "Type of resource equals only AWS::CodeGuruProfiler::ProfilingGroup",
+        "type" : "string",
+        "enum" : [ "AWS::CodeGuruProfiler::ProfilingGroup" ]
+      },
+      "Properties" : {
+        "type" : "object",
+        "properties" : {
+          "ProfilingGroupName" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codeguruprofiler-profilinggroup.html#cfn-codeguruprofiler-profilinggroup-profilinggroupname",
+            "type" : [ "string", "object" ]
+          }
+        },
+        "required" : [ "ProfilingGroupName" ],
+        "additionalProperties" : false
+      },
+      "DependsOn" : {
+        "type" : [ "string", "array" ],
+        "items" : {
+          "type" : "string"
+        }
+      }
+    },
+    "required" : [ "Type", "Properties" ],
+    "additionalProperties" : false
+  },
   "AWS_CodePipeline_CustomActionType" : {
     "type" : "object",
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html",
@@ -8057,6 +8087,9 @@
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-endpoint.html#cfn-dms-endpoint-kmskeyid",
             "type" : [ "string", "object" ]
           },
+          "KafkaSettings" : {
+            "$ref" : "#/definitions/AWS_DMS_Endpoint_KafkaSettings"
+          },
           "Port" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-endpoint.html#cfn-dms-endpoint-port",
             "type" : [ "integer", "object" ]
@@ -9111,6 +9144,10 @@
             },
             "minItems" : 0
           },
+          "VpcId" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-clientvpnendpoint.html#cfn-ec2-clientvpnendpoint-vpcid",
+            "type" : [ "string", "object" ]
+          },
           "AuthenticationOptions" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-clientvpnendpoint.html#cfn-ec2-clientvpnendpoint-authenticationoptions",
             "type" : "array",
@@ -9134,6 +9171,14 @@
           "TransportProtocol" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-clientvpnendpoint.html#cfn-ec2-clientvpnendpoint-transportprotocol",
             "type" : [ "string", "object" ]
+          },
+          "SecurityGroupIds" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-clientvpnendpoint.html#cfn-ec2-clientvpnendpoint-securitygroupids",
+            "type" : "array",
+            "items" : {
+              "type" : [ "string", "object" ]
+            },
+            "minItems" : 0
           },
           "VpnPort" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-clientvpnendpoint.html#cfn-ec2-clientvpnendpoint-vpnport",
@@ -20003,6 +20048,324 @@
     "required" : [ "Type", "Properties" ],
     "additionalProperties" : false
   },
+  "AWS_NetworkManager_CustomerGatewayAssociation" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-customergatewayassociation.html",
+    "properties" : {
+      "Type" : {
+        "description" : "Type of resource equals only AWS::NetworkManager::CustomerGatewayAssociation",
+        "type" : "string",
+        "enum" : [ "AWS::NetworkManager::CustomerGatewayAssociation" ]
+      },
+      "Properties" : {
+        "type" : "object",
+        "properties" : {
+          "GlobalNetworkId" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-customergatewayassociation.html#cfn-networkmanager-customergatewayassociation-globalnetworkid",
+            "type" : [ "string", "object" ]
+          },
+          "CustomerGatewayArn" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-customergatewayassociation.html#cfn-networkmanager-customergatewayassociation-customergatewayarn",
+            "type" : [ "string", "object" ]
+          },
+          "DeviceId" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-customergatewayassociation.html#cfn-networkmanager-customergatewayassociation-deviceid",
+            "type" : [ "string", "object" ]
+          },
+          "LinkId" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-customergatewayassociation.html#cfn-networkmanager-customergatewayassociation-linkid",
+            "type" : [ "string", "object" ]
+          }
+        },
+        "required" : [ "GlobalNetworkId", "CustomerGatewayArn", "DeviceId" ],
+        "additionalProperties" : false
+      },
+      "DependsOn" : {
+        "type" : [ "string", "array" ],
+        "items" : {
+          "type" : "string"
+        }
+      }
+    },
+    "required" : [ "Type", "Properties" ],
+    "additionalProperties" : false
+  },
+  "AWS_NetworkManager_Device" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-device.html",
+    "properties" : {
+      "Type" : {
+        "description" : "Type of resource equals only AWS::NetworkManager::Device",
+        "type" : "string",
+        "enum" : [ "AWS::NetworkManager::Device" ]
+      },
+      "Properties" : {
+        "type" : "object",
+        "properties" : {
+          "Description" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-device.html#cfn-networkmanager-device-description",
+            "type" : [ "string", "object" ]
+          },
+          "Tags" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-device.html#cfn-networkmanager-device-tags",
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/Tag"
+            },
+            "minItems" : 0
+          },
+          "GlobalNetworkId" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-device.html#cfn-networkmanager-device-globalnetworkid",
+            "type" : [ "string", "object" ]
+          },
+          "Location" : {
+            "$ref" : "#/definitions/AWS_NetworkManager_Device_Location"
+          },
+          "Model" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-device.html#cfn-networkmanager-device-model",
+            "type" : [ "string", "object" ]
+          },
+          "SerialNumber" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-device.html#cfn-networkmanager-device-serialnumber",
+            "type" : [ "string", "object" ]
+          },
+          "SiteId" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-device.html#cfn-networkmanager-device-siteid",
+            "type" : [ "string", "object" ]
+          },
+          "Type" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-device.html#cfn-networkmanager-device-type",
+            "type" : [ "string", "object" ]
+          },
+          "Vendor" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-device.html#cfn-networkmanager-device-vendor",
+            "type" : [ "string", "object" ]
+          }
+        },
+        "required" : [ "GlobalNetworkId" ],
+        "additionalProperties" : false
+      },
+      "DependsOn" : {
+        "type" : [ "string", "array" ],
+        "items" : {
+          "type" : "string"
+        }
+      }
+    },
+    "required" : [ "Type", "Properties" ],
+    "additionalProperties" : false
+  },
+  "AWS_NetworkManager_GlobalNetwork" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-globalnetwork.html",
+    "properties" : {
+      "Type" : {
+        "description" : "Type of resource equals only AWS::NetworkManager::GlobalNetwork",
+        "type" : "string",
+        "enum" : [ "AWS::NetworkManager::GlobalNetwork" ]
+      },
+      "Properties" : {
+        "type" : "object",
+        "properties" : {
+          "Description" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-globalnetwork.html#cfn-networkmanager-globalnetwork-description",
+            "type" : [ "string", "object" ]
+          },
+          "Tags" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-globalnetwork.html#cfn-networkmanager-globalnetwork-tags",
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/Tag"
+            },
+            "minItems" : 0
+          }
+        },
+        "additionalProperties" : false
+      },
+      "DependsOn" : {
+        "type" : [ "string", "array" ],
+        "items" : {
+          "type" : "string"
+        }
+      }
+    },
+    "required" : [ "Type" ],
+    "additionalProperties" : false
+  },
+  "AWS_NetworkManager_Link" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-link.html",
+    "properties" : {
+      "Type" : {
+        "description" : "Type of resource equals only AWS::NetworkManager::Link",
+        "type" : "string",
+        "enum" : [ "AWS::NetworkManager::Link" ]
+      },
+      "Properties" : {
+        "type" : "object",
+        "properties" : {
+          "GlobalNetworkId" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-link.html#cfn-networkmanager-link-globalnetworkid",
+            "type" : [ "string", "object" ]
+          },
+          "SiteId" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-link.html#cfn-networkmanager-link-siteid",
+            "type" : [ "string", "object" ]
+          },
+          "Bandwidth" : {
+            "$ref" : "#/definitions/AWS_NetworkManager_Link_Bandwidth"
+          },
+          "Provider" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-link.html#cfn-networkmanager-link-provider",
+            "type" : [ "string", "object" ]
+          },
+          "Description" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-link.html#cfn-networkmanager-link-description",
+            "type" : [ "string", "object" ]
+          },
+          "Tags" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-link.html#cfn-networkmanager-link-tags",
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/Tag"
+            },
+            "minItems" : 0
+          },
+          "Type" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-link.html#cfn-networkmanager-link-type",
+            "type" : [ "string", "object" ]
+          }
+        },
+        "required" : [ "GlobalNetworkId", "SiteId" ],
+        "additionalProperties" : false
+      },
+      "DependsOn" : {
+        "type" : [ "string", "array" ],
+        "items" : {
+          "type" : "string"
+        }
+      }
+    },
+    "required" : [ "Type", "Properties" ],
+    "additionalProperties" : false
+  },
+  "AWS_NetworkManager_LinkAssociation" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-linkassociation.html",
+    "properties" : {
+      "Type" : {
+        "description" : "Type of resource equals only AWS::NetworkManager::LinkAssociation",
+        "type" : "string",
+        "enum" : [ "AWS::NetworkManager::LinkAssociation" ]
+      },
+      "Properties" : {
+        "type" : "object",
+        "properties" : {
+          "GlobalNetworkId" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-linkassociation.html#cfn-networkmanager-linkassociation-globalnetworkid",
+            "type" : [ "string", "object" ]
+          },
+          "DeviceId" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-linkassociation.html#cfn-networkmanager-linkassociation-deviceid",
+            "type" : [ "string", "object" ]
+          },
+          "LinkId" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-linkassociation.html#cfn-networkmanager-linkassociation-linkid",
+            "type" : [ "string", "object" ]
+          }
+        },
+        "required" : [ "GlobalNetworkId", "DeviceId", "LinkId" ],
+        "additionalProperties" : false
+      },
+      "DependsOn" : {
+        "type" : [ "string", "array" ],
+        "items" : {
+          "type" : "string"
+        }
+      }
+    },
+    "required" : [ "Type", "Properties" ],
+    "additionalProperties" : false
+  },
+  "AWS_NetworkManager_Site" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-site.html",
+    "properties" : {
+      "Type" : {
+        "description" : "Type of resource equals only AWS::NetworkManager::Site",
+        "type" : "string",
+        "enum" : [ "AWS::NetworkManager::Site" ]
+      },
+      "Properties" : {
+        "type" : "object",
+        "properties" : {
+          "Description" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-site.html#cfn-networkmanager-site-description",
+            "type" : [ "string", "object" ]
+          },
+          "Tags" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-site.html#cfn-networkmanager-site-tags",
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/Tag"
+            },
+            "minItems" : 0
+          },
+          "GlobalNetworkId" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-site.html#cfn-networkmanager-site-globalnetworkid",
+            "type" : [ "string", "object" ]
+          },
+          "Location" : {
+            "$ref" : "#/definitions/AWS_NetworkManager_Site_Location"
+          }
+        },
+        "required" : [ "GlobalNetworkId" ],
+        "additionalProperties" : false
+      },
+      "DependsOn" : {
+        "type" : [ "string", "array" ],
+        "items" : {
+          "type" : "string"
+        }
+      }
+    },
+    "required" : [ "Type", "Properties" ],
+    "additionalProperties" : false
+  },
+  "AWS_NetworkManager_TransitGatewayRegistration" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-transitgatewayregistration.html",
+    "properties" : {
+      "Type" : {
+        "description" : "Type of resource equals only AWS::NetworkManager::TransitGatewayRegistration",
+        "type" : "string",
+        "enum" : [ "AWS::NetworkManager::TransitGatewayRegistration" ]
+      },
+      "Properties" : {
+        "type" : "object",
+        "properties" : {
+          "GlobalNetworkId" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-transitgatewayregistration.html#cfn-networkmanager-transitgatewayregistration-globalnetworkid",
+            "type" : [ "string", "object" ]
+          },
+          "TransitGatewayArn" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-transitgatewayregistration.html#cfn-networkmanager-transitgatewayregistration-transitgatewayarn",
+            "type" : [ "string", "object" ]
+          }
+        },
+        "required" : [ "GlobalNetworkId", "TransitGatewayArn" ],
+        "additionalProperties" : false
+      },
+      "DependsOn" : {
+        "type" : [ "string", "array" ],
+        "items" : {
+          "type" : "string"
+        }
+      }
+    },
+    "required" : [ "Type", "Properties" ],
+    "additionalProperties" : false
+  },
   "AWS_OpsWorks_App" : {
     "type" : "object",
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-app.html",
@@ -25690,6 +26053,10 @@
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-launchroleconstraint.html#cfn-servicecatalog-launchroleconstraint-description",
             "type" : [ "string", "object" ]
           },
+          "LocalRoleName" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-launchroleconstraint.html#cfn-servicecatalog-launchroleconstraint-localrolename",
+            "type" : [ "string", "object" ]
+          },
           "AcceptLanguage" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-launchroleconstraint.html#cfn-servicecatalog-launchroleconstraint-acceptlanguage",
             "type" : [ "string", "object" ]
@@ -25707,7 +26074,7 @@
             "type" : [ "string", "object" ]
           }
         },
-        "required" : [ "PortfolioId", "ProductId", "RoleArn" ],
+        "required" : [ "PortfolioId", "ProductId" ],
         "additionalProperties" : false
       },
       "DependsOn" : {
@@ -35472,6 +35839,21 @@
       },
       "ServiceAccessRoleArn" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dms-endpoint-elasticsearchsettings.html#cfn-dms-endpoint-elasticsearchsettings-serviceaccessrolearn",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_DMS_Endpoint_KafkaSettings" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dms-endpoint-kafkasettings.html",
+    "properties" : {
+      "Broker" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dms-endpoint-kafkasettings.html#cfn-dms-endpoint-kafkasettings-broker",
+        "type" : [ "string", "object" ]
+      },
+      "Topic" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dms-endpoint-kafkasettings.html#cfn-dms-endpoint-kafkasettings-topic",
         "type" : [ "string", "object" ]
       }
     },
@@ -48448,6 +48830,59 @@
     },
     "additionalProperties" : false
   },
+  "AWS_NetworkManager_Device_Location" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-networkmanager-device-location.html",
+    "properties" : {
+      "Address" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-networkmanager-device-location.html#cfn-networkmanager-device-location-address",
+        "type" : [ "string", "object" ]
+      },
+      "Latitude" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-networkmanager-device-location.html#cfn-networkmanager-device-location-latitude",
+        "type" : [ "string", "object" ]
+      },
+      "Longitude" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-networkmanager-device-location.html#cfn-networkmanager-device-location-longitude",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_NetworkManager_Link_Bandwidth" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-networkmanager-link-bandwidth.html",
+    "properties" : {
+      "DownloadSpeed" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-networkmanager-link-bandwidth.html#cfn-networkmanager-link-bandwidth-downloadspeed",
+        "type" : [ "integer", "object" ]
+      },
+      "UploadSpeed" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-networkmanager-link-bandwidth.html#cfn-networkmanager-link-bandwidth-uploadspeed",
+        "type" : [ "integer", "object" ]
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_NetworkManager_Site_Location" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-networkmanager-site-location.html",
+    "properties" : {
+      "Address" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-networkmanager-site-location.html#cfn-networkmanager-site-location-address",
+        "type" : [ "string", "object" ]
+      },
+      "Latitude" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-networkmanager-site-location.html#cfn-networkmanager-site-location-latitude",
+        "type" : [ "string", "object" ]
+      },
+      "Longitude" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-networkmanager-site-location.html#cfn-networkmanager-site-location-longitude",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "additionalProperties" : false
+  },
   "AWS_OpsWorks_App_DataSource" : {
     "type" : "object",
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-opsworks-app-datasource.html",
@@ -54515,6 +54950,8 @@
         }, {
           "$ref" : "#/definitions/AWS_CodeDeploy_DeploymentGroup"
         }, {
+          "$ref" : "#/definitions/AWS_CodeGuruProfiler_ProfilingGroup"
+        }, {
           "$ref" : "#/definitions/AWS_CodePipeline_CustomActionType"
         }, {
           "$ref" : "#/definitions/AWS_CodePipeline_Pipeline"
@@ -55035,6 +55472,20 @@
         }, {
           "$ref" : "#/definitions/AWS_Neptune_DBSubnetGroup"
         }, {
+          "$ref" : "#/definitions/AWS_NetworkManager_CustomerGatewayAssociation"
+        }, {
+          "$ref" : "#/definitions/AWS_NetworkManager_Device"
+        }, {
+          "$ref" : "#/definitions/AWS_NetworkManager_GlobalNetwork"
+        }, {
+          "$ref" : "#/definitions/AWS_NetworkManager_Link"
+        }, {
+          "$ref" : "#/definitions/AWS_NetworkManager_LinkAssociation"
+        }, {
+          "$ref" : "#/definitions/AWS_NetworkManager_Site"
+        }, {
+          "$ref" : "#/definitions/AWS_NetworkManager_TransitGatewayRegistration"
+        }, {
           "$ref" : "#/definitions/AWS_OpsWorks_App"
         }, {
           "$ref" : "#/definitions/AWS_OpsWorks_ElasticLoadBalancerAttachment"
@@ -55372,7 +55823,7 @@
       "$ref": "#/definitions/resources"
     }
   },
-  "description": "CFN JSON specification generated from version 11.5.0",
+  "description": "CFN JSON specification generated from version 11.6.0",
   "required": [
     "Resources"
   ]


### PR DESCRIPTION
https://github.com/aws-cloudformation/aws-cloudformation-template-schema/issues/32

https://github.com/aws-cloudformation/aws-cloudformation-template-schema/blob/master/docs/tool/instructions.md

as described in https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code/pull/76

---

```java
Exception in thread "main" java.lang.UnsupportedClassVersionError: org/apache/logging/log4j/util/StackLocator has been compiled by a more recent version of the Java Runtime (class file version 53.0), this version of the Java Runtime only recognizes class file versions up to 52.0
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:760)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:467)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:368)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:362)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:361)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at org.apache.logging.log4j.util.StackLocatorUtil.<clinit>(StackLocatorUtil.java:28)
	at org.apache.logging.log4j.core.impl.ThrowableProxy.<init>(ThrowableProxy.java:108)
	at org.apache.logging.log4j.core.impl.ThrowableProxy.<init>(ThrowableProxy.java:93)
	at org.apache.logging.log4j.core.impl.MutableLogEvent.getThrownProxy(MutableLogEvent.java:351)
	at org.apache.logging.log4j.core.pattern.ExtendedThrowablePatternConverter.format(ExtendedThrowablePatternConverter.java:63)
	at org.apache.logging.log4j.core.pattern.PatternFormatter.format(PatternFormatter.java:38)
	at org.apache.logging.log4j.core.layout.PatternLayout$PatternSerializer.toSerializable(PatternLayout.java:334)
	at org.apache.logging.log4j.core.layout.PatternLayout.toText(PatternLayout.java:233)
	at org.apache.logging.log4j.core.layout.PatternLayout.encode(PatternLayout.java:218)
	at org.apache.logging.log4j.core.layout.PatternLayout.encode(PatternLayout.java:58)
	at org.apache.logging.log4j.core.appender.AbstractOutputStreamAppender.directEncodeEvent(AbstractOutputStreamAppender.java:197)
	at org.apache.logging.log4j.core.appender.AbstractOutputStreamAppender.tryAppend(AbstractOutputStreamAppender.java:190)
	at org.apache.logging.log4j.core.appender.AbstractOutputStreamAppender.append(AbstractOutputStreamAppender.java:181)
	at org.apache.logging.log4j.core.config.AppenderControl.tryCallAppender(AppenderControl.java:156)
	at org.apache.logging.log4j.core.config.AppenderControl.callAppender0(AppenderControl.java:129)
	at org.apache.logging.log4j.core.config.AppenderControl.callAppenderPreventRecursion(AppenderControl.java:120)
	at org.apache.logging.log4j.core.config.AppenderControl.callAppender(AppenderControl.java:84)
	at org.apache.logging.log4j.core.config.LoggerConfig.callAppenders(LoggerConfig.java:464)
	at org.apache.logging.log4j.core.config.LoggerConfig.processLogEvent(LoggerConfig.java:448)
	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:431)
	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:406)
	at org.apache.logging.log4j.core.config.DefaultReliabilityStrategy.log(DefaultReliabilityStrategy.java:49)
	at org.apache.logging.log4j.core.Logger.logMessage(Logger.java:146)
	at org.apache.logging.log4j.spi.AbstractLogger.tryLogMessage(AbstractLogger.java:2170)
	at org.apache.logging.log4j.spi.AbstractLogger.logMessageTrackRecursion(AbstractLogger.java:2125)
	at org.apache.logging.log4j.spi.AbstractLogger.logMessageSafely(AbstractLogger.java:2108)
	at org.apache.logging.log4j.spi.AbstractLogger.logMessage(AbstractLogger.java:2002)
	at org.apache.logging.log4j.spi.AbstractLogger.logIfEnabled(AbstractLogger.java:1974)
	at org.apache.logging.log4j.spi.AbstractLogger.fatal(AbstractLogger.java:1054)
	at aws.cfn.codegen.json.Codegen.lambda$generate$7(Codegen.java:205)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1540)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:418)
	at aws.cfn.codegen.json.Codegen.generate(Codegen.java:209)
	at aws.cfn.codegen.json.Main.execute(Main.java:81)
	at aws.cfn.codegen.json.Main.main(Main.java:89)
```

so I upgraded from Java 8:
```shell
$ java -version
java version "1.8.0_60"
Java(TM) SE Runtime Environment (build 1.8.0_60-b27)
Java HotSpot(TM) 64-Bit Server VM (build 25.60-b23, mixed mode)
$ brew cask install java
$ java -version
openjdk version "14" 2020-03-17
OpenJDK Runtime Environment (build 14+36-1461)
OpenJDK 64-Bit Server VM (build 14+36-1461, mixed mode, sharing)
```

---

```java
aws.cfn.codegen.CfnSpecificationException: Json referenced but not defined in AWS::ResourceGroups::Group
	at aws.cfn.codegen.CfnSpecification.lambda$validate$0(CfnSpecification.java:35) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.Optional.ifPresent(Optional.java:176) ~[?:?]
	at aws.cfn.codegen.CfnSpecification.lambda$validate$1(CfnSpecification.java:32) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.LinkedHashMap.forEach(LinkedHashMap.java:723) ~[?:?]
	at aws.cfn.codegen.CfnSpecification.lambda$validate$2(CfnSpecification.java:30) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.LinkedHashMap.forEach(LinkedHashMap.java:723) ~[?:?]
	at aws.cfn.codegen.CfnSpecification.validate(CfnSpecification.java:28) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Codegen.loadSpecification(Codegen.java:66) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Codegen.lambda$generate$7(Codegen.java:199) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195) [?:?]
	at java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1694) [?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) [?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) [?:?]
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) [?:?]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) [?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) [?:?]
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497) [?:?]
	at aws.cfn.codegen.json.Codegen.generate(Codegen.java:209) [aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Main.execute(Main.java:81) [aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Main.main(Main.java:89) [aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
Exception in thread "main" java.lang.RuntimeException: aws.cfn.codegen.CfnSpecificationException: Json referenced but not defined in AWS::ResourceGroups::Group
	at aws.cfn.codegen.json.Codegen.lambda$generate$7(Codegen.java:206)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1694)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
	at aws.cfn.codegen.json.Codegen.generate(Codegen.java:209)
	at aws.cfn.codegen.json.Main.execute(Main.java:81)
	at aws.cfn.codegen.json.Main.main(Main.java:89)
Caused by: aws.cfn.codegen.CfnSpecificationException: Json referenced but not defined in AWS::ResourceGroups::Group
	at aws.cfn.codegen.CfnSpecification.lambda$validate$0(CfnSpecification.java:35)
	at java.base/java.util.Optional.ifPresent(Optional.java:176)
	at aws.cfn.codegen.CfnSpecification.lambda$validate$1(CfnSpecification.java:32)
	at java.base/java.util.LinkedHashMap.forEach(LinkedHashMap.java:723)
	at aws.cfn.codegen.CfnSpecification.lambda$validate$2(CfnSpecification.java:30)
	at java.base/java.util.LinkedHashMap.forEach(LinkedHashMap.java:723)
	at aws.cfn.codegen.CfnSpecification.validate(CfnSpecification.java:28)
	at aws.cfn.codegen.json.Codegen.loadSpecification(Codegen.java:66)
	at aws.cfn.codegen.json.Codegen.lambda$generate$7(Codegen.java:199)
	... 11 more
```

so I removed [`AWS::ResourceGroups::Group`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-resourcegroups-group.html) from the [CloudFormation Resource Specification](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html) and used [that](https://gist.githubusercontent.com/PatMyron/b05935a62fac1c136a2b6809e0e1b670/raw/918e90df7bee01fe632da3b00a58d6f41f9d7286/CloudFormationResourceSpecification.json) instead:

```shell
aws-cloudformation-template-schema $ git diff
diff --git a/src/main/resources/config.yml b/src/main/resources/config.yml
index f58bb07..d3aa04c 100644
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -33,7 +33,7 @@ settings:
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html
 specifications:
   # US Region
-  us-east-1: https://d1uauaxba7bl26.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json
+  us-east-1: https://gist.githubusercontent.com/PatMyron/b05935a62fac1c136a2b6809e0e1b670/raw/918e90df7bee01fe632da3b00a58d6f41f9d7286/CloudFormationResourceSpecification.json
```