### PR TITLE
CloudFormation Template Schema 12.3.0

### DIFF
--- a/schema/all-spec.json
+++ b/schema/all-spec.json
@@ -15491,6 +15491,14 @@
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-devendpoint.html#cfn-glue-devendpoint-subnetid",
             "type" : [ "string", "object" ]
           },
+          "PublicKeys" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-devendpoint.html#cfn-glue-devendpoint-publickeys",
+            "type" : "array",
+            "items" : {
+              "type" : [ "string", "object" ]
+            },
+            "minItems" : 0
+          },
           "SecurityGroupIds" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-devendpoint.html#cfn-glue-devendpoint-securitygroupids",
             "type" : "array",
@@ -15684,6 +15692,10 @@
           "NumberOfWorkers" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-mltransform.html#cfn-glue-mltransform-numberofworkers",
             "type" : [ "integer", "object" ]
+          },
+          "Tags" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-mltransform.html#cfn-glue-mltransform-tags",
+            "type" : [ "object" ]
           },
           "Name" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-mltransform.html#cfn-glue-mltransform-name",
@@ -17282,6 +17294,339 @@
           }
         },
         "required" : [ "GroupName", "Users" ],
+        "additionalProperties" : false
+      },
+      "DependsOn" : {
+        "type" : [ "string", "array" ],
+        "items" : {
+          "type" : "string"
+        }
+      }
+    },
+    "required" : [ "Type", "Properties" ],
+    "additionalProperties" : false
+  },
+  "AWS_ImageBuilder_Component" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-component.html",
+    "properties" : {
+      "Type" : {
+        "description" : "Type of resource equals only AWS::ImageBuilder::Component",
+        "type" : "string",
+        "enum" : [ "AWS::ImageBuilder::Component" ]
+      },
+      "Properties" : {
+        "type" : "object",
+        "properties" : {
+          "Name" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-component.html#cfn-imagebuilder-component-name",
+            "type" : [ "string", "object" ]
+          },
+          "Version" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-component.html#cfn-imagebuilder-component-version",
+            "type" : [ "string", "object" ]
+          },
+          "Description" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-component.html#cfn-imagebuilder-component-description",
+            "type" : [ "string", "object" ]
+          },
+          "ChangeDescription" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-component.html#cfn-imagebuilder-component-changedescription",
+            "type" : [ "string", "object" ]
+          },
+          "Platform" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-component.html#cfn-imagebuilder-component-platform",
+            "type" : [ "string", "object" ]
+          },
+          "Data" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-component.html#cfn-imagebuilder-component-data",
+            "type" : [ "string", "object" ]
+          },
+          "KmsKeyId" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-component.html#cfn-imagebuilder-component-kmskeyid",
+            "type" : [ "string", "object" ]
+          },
+          "Tags" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-component.html#cfn-imagebuilder-component-tags",
+            "type" : "object",
+            "patternProperties" : {
+              "[a-zA-Z0-9]+" : {
+                "type" : [ "string", "object" ]
+              }
+            }
+          },
+          "Uri" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-component.html#cfn-imagebuilder-component-uri",
+            "type" : [ "string", "object" ]
+          }
+        },
+        "required" : [ "Name", "Version", "Platform" ],
+        "additionalProperties" : false
+      },
+      "DependsOn" : {
+        "type" : [ "string", "array" ],
+        "items" : {
+          "type" : "string"
+        }
+      }
+    },
+    "required" : [ "Type", "Properties" ],
+    "additionalProperties" : false
+  },
+  "AWS_ImageBuilder_DistributionConfiguration" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-distributionconfiguration.html",
+    "properties" : {
+      "Type" : {
+        "description" : "Type of resource equals only AWS::ImageBuilder::DistributionConfiguration",
+        "type" : "string",
+        "enum" : [ "AWS::ImageBuilder::DistributionConfiguration" ]
+      },
+      "Properties" : {
+        "type" : "object",
+        "properties" : {
+          "Name" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-distributionconfiguration.html#cfn-imagebuilder-distributionconfiguration-name",
+            "type" : [ "string", "object" ]
+          },
+          "Description" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-distributionconfiguration.html#cfn-imagebuilder-distributionconfiguration-description",
+            "type" : [ "string", "object" ]
+          },
+          "Distributions" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-distributionconfiguration.html#cfn-imagebuilder-distributionconfiguration-distributions",
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/AWS_ImageBuilder_DistributionConfiguration_Distribution"
+            },
+            "minItems" : 0
+          },
+          "Tags" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-distributionconfiguration.html#cfn-imagebuilder-distributionconfiguration-tags",
+            "type" : "object",
+            "patternProperties" : {
+              "[a-zA-Z0-9]+" : {
+                "type" : [ "string", "object" ]
+              }
+            }
+          }
+        },
+        "required" : [ "Name", "Distributions" ],
+        "additionalProperties" : false
+      },
+      "DependsOn" : {
+        "type" : [ "string", "array" ],
+        "items" : {
+          "type" : "string"
+        }
+      }
+    },
+    "required" : [ "Type", "Properties" ],
+    "additionalProperties" : false
+  },
+  "AWS_ImageBuilder_ImagePipeline" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagepipeline.html",
+    "properties" : {
+      "Type" : {
+        "description" : "Type of resource equals only AWS::ImageBuilder::ImagePipeline",
+        "type" : "string",
+        "enum" : [ "AWS::ImageBuilder::ImagePipeline" ]
+      },
+      "Properties" : {
+        "type" : "object",
+        "properties" : {
+          "Name" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagepipeline.html#cfn-imagebuilder-imagepipeline-name",
+            "type" : [ "string", "object" ]
+          },
+          "Description" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagepipeline.html#cfn-imagebuilder-imagepipeline-description",
+            "type" : [ "string", "object" ]
+          },
+          "ImageTestsConfiguration" : {
+            "$ref" : "#/definitions/AWS_ImageBuilder_ImagePipeline_ImageTestsConfiguration"
+          },
+          "Status" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagepipeline.html#cfn-imagebuilder-imagepipeline-status",
+            "type" : [ "string", "object" ]
+          },
+          "Schedule" : {
+            "$ref" : "#/definitions/AWS_ImageBuilder_ImagePipeline_Schedule"
+          },
+          "ImageRecipeArn" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagepipeline.html#cfn-imagebuilder-imagepipeline-imagerecipearn",
+            "type" : [ "string", "object" ]
+          },
+          "DistributionConfigurationArn" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagepipeline.html#cfn-imagebuilder-imagepipeline-distributionconfigurationarn",
+            "type" : [ "string", "object" ]
+          },
+          "InfrastructureConfigurationArn" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagepipeline.html#cfn-imagebuilder-imagepipeline-infrastructureconfigurationarn",
+            "type" : [ "string", "object" ]
+          },
+          "Tags" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagepipeline.html#cfn-imagebuilder-imagepipeline-tags",
+            "type" : "object",
+            "patternProperties" : {
+              "[a-zA-Z0-9]+" : {
+                "type" : [ "string", "object" ]
+              }
+            }
+          }
+        },
+        "required" : [ "Name", "ImageRecipeArn", "InfrastructureConfigurationArn" ],
+        "additionalProperties" : false
+      },
+      "DependsOn" : {
+        "type" : [ "string", "array" ],
+        "items" : {
+          "type" : "string"
+        }
+      }
+    },
+    "required" : [ "Type", "Properties" ],
+    "additionalProperties" : false
+  },
+  "AWS_ImageBuilder_ImageRecipe" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagerecipe.html",
+    "properties" : {
+      "Type" : {
+        "description" : "Type of resource equals only AWS::ImageBuilder::ImageRecipe",
+        "type" : "string",
+        "enum" : [ "AWS::ImageBuilder::ImageRecipe" ]
+      },
+      "Properties" : {
+        "type" : "object",
+        "properties" : {
+          "Name" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagerecipe.html#cfn-imagebuilder-imagerecipe-name",
+            "type" : [ "string", "object" ]
+          },
+          "Description" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagerecipe.html#cfn-imagebuilder-imagerecipe-description",
+            "type" : [ "string", "object" ]
+          },
+          "Version" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagerecipe.html#cfn-imagebuilder-imagerecipe-version",
+            "type" : [ "string", "object" ]
+          },
+          "Components" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagerecipe.html#cfn-imagebuilder-imagerecipe-components",
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/AWS_ImageBuilder_ImageRecipe_ComponentConfiguration"
+            },
+            "minItems" : 0
+          },
+          "BlockDeviceMappings" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagerecipe.html#cfn-imagebuilder-imagerecipe-blockdevicemappings",
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/AWS_ImageBuilder_ImageRecipe_InstanceBlockDeviceMapping"
+            },
+            "minItems" : 0
+          },
+          "ParentImage" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagerecipe.html#cfn-imagebuilder-imagerecipe-parentimage",
+            "type" : [ "string", "object" ]
+          },
+          "Tags" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagerecipe.html#cfn-imagebuilder-imagerecipe-tags",
+            "type" : "object",
+            "patternProperties" : {
+              "[a-zA-Z0-9]+" : {
+                "type" : [ "string", "object" ]
+              }
+            }
+          }
+        },
+        "required" : [ "Name", "Version", "Components", "ParentImage" ],
+        "additionalProperties" : false
+      },
+      "DependsOn" : {
+        "type" : [ "string", "array" ],
+        "items" : {
+          "type" : "string"
+        }
+      }
+    },
+    "required" : [ "Type", "Properties" ],
+    "additionalProperties" : false
+  },
+  "AWS_ImageBuilder_InfrastructureConfiguration" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html",
+    "properties" : {
+      "Type" : {
+        "description" : "Type of resource equals only AWS::ImageBuilder::InfrastructureConfiguration",
+        "type" : "string",
+        "enum" : [ "AWS::ImageBuilder::InfrastructureConfiguration" ]
+      },
+      "Properties" : {
+        "type" : "object",
+        "properties" : {
+          "Name" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html#cfn-imagebuilder-infrastructureconfiguration-name",
+            "type" : [ "string", "object" ]
+          },
+          "Description" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html#cfn-imagebuilder-infrastructureconfiguration-description",
+            "type" : [ "string", "object" ]
+          },
+          "InstanceTypes" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html#cfn-imagebuilder-infrastructureconfiguration-instancetypes",
+            "type" : "array",
+            "items" : {
+              "type" : [ "string", "object" ]
+            },
+            "minItems" : 0
+          },
+          "SecurityGroupIds" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html#cfn-imagebuilder-infrastructureconfiguration-securitygroupids",
+            "type" : "array",
+            "items" : {
+              "type" : [ "string", "object" ]
+            },
+            "minItems" : 0
+          },
+          "Logging" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html#cfn-imagebuilder-infrastructureconfiguration-logging",
+            "type" : [ "object" ]
+          },
+          "SubnetId" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html#cfn-imagebuilder-infrastructureconfiguration-subnetid",
+            "type" : [ "string", "object" ]
+          },
+          "KeyPair" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html#cfn-imagebuilder-infrastructureconfiguration-keypair",
+            "type" : [ "string", "object" ]
+          },
+          "TerminateInstanceOnFailure" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html#cfn-imagebuilder-infrastructureconfiguration-terminateinstanceonfailure",
+            "type" : [ "boolean", "object" ]
+          },
+          "InstanceProfileName" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html#cfn-imagebuilder-infrastructureconfiguration-instanceprofilename",
+            "type" : [ "string", "object" ]
+          },
+          "SnsTopicArn" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html#cfn-imagebuilder-infrastructureconfiguration-snstopicarn",
+            "type" : [ "string", "object" ]
+          },
+          "Tags" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html#cfn-imagebuilder-infrastructureconfiguration-tags",
+            "type" : "object",
+            "patternProperties" : {
+              "[a-zA-Z0-9]+" : {
+                "type" : [ "string", "object" ]
+              }
+            }
+          }
+        },
+        "required" : [ "Name", "InstanceProfileName" ],
         "additionalProperties" : false
       },
       "DependsOn" : {
@@ -44652,6 +44997,152 @@
     "required" : [ "PolicyDocument", "PolicyName" ],
     "additionalProperties" : false
   },
+  "AWS_ImageBuilder_DistributionConfiguration_Distribution" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-distributionconfiguration-distribution.html",
+    "properties" : {
+      "Region" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-distributionconfiguration-distribution.html#cfn-imagebuilder-distributionconfiguration-distribution-region",
+        "type" : [ "string", "object" ]
+      },
+      "AmiDistributionConfiguration" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-distributionconfiguration-distribution.html#cfn-imagebuilder-distributionconfiguration-distribution-amidistributionconfiguration",
+        "type" : [ "object" ]
+      },
+      "LicenseConfigurationArns" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-distributionconfiguration-distribution.html#cfn-imagebuilder-distributionconfiguration-distribution-licenseconfigurationarns",
+        "type" : "array",
+        "items" : {
+          "type" : [ "string", "object" ]
+        },
+        "minItems" : 0
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_ImageBuilder_ImagePipeline_ImageTestsConfiguration" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagepipeline-imagetestsconfiguration.html",
+    "properties" : {
+      "ImageTestsEnabled" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagepipeline-imagetestsconfiguration.html#cfn-imagebuilder-imagepipeline-imagetestsconfiguration-imagetestsenabled",
+        "type" : [ "boolean", "object" ]
+      },
+      "TimeoutMinutes" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagepipeline-imagetestsconfiguration.html#cfn-imagebuilder-imagepipeline-imagetestsconfiguration-timeoutminutes",
+        "type" : [ "integer", "object" ]
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_ImageBuilder_ImagePipeline_Schedule" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagepipeline-schedule.html",
+    "properties" : {
+      "ScheduleExpression" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagepipeline-schedule.html#cfn-imagebuilder-imagepipeline-schedule-scheduleexpression",
+        "type" : [ "string", "object" ]
+      },
+      "PipelineExecutionStartCondition" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagepipeline-schedule.html#cfn-imagebuilder-imagepipeline-schedule-pipelineexecutionstartcondition",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_ImageBuilder_ImageRecipe_ComponentConfiguration" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-componentconfiguration.html",
+    "properties" : {
+      "ComponentArn" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-componentconfiguration.html#cfn-imagebuilder-imagerecipe-componentconfiguration-componentarn",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_ImageBuilder_ImageRecipe_EbsInstanceBlockDeviceSpecification" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-ebsinstanceblockdevicespecification.html",
+    "properties" : {
+      "Encrypted" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-ebsinstanceblockdevicespecification.html#cfn-imagebuilder-imagerecipe-ebsinstanceblockdevicespecification-encrypted",
+        "type" : [ "boolean", "object" ]
+      },
+      "DeleteOnTermination" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-ebsinstanceblockdevicespecification.html#cfn-imagebuilder-imagerecipe-ebsinstanceblockdevicespecification-deleteontermination",
+        "type" : [ "boolean", "object" ]
+      },
+      "Iops" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-ebsinstanceblockdevicespecification.html#cfn-imagebuilder-imagerecipe-ebsinstanceblockdevicespecification-iops",
+        "type" : [ "integer", "object" ]
+      },
+      "KmsKeyId" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-ebsinstanceblockdevicespecification.html#cfn-imagebuilder-imagerecipe-ebsinstanceblockdevicespecification-kmskeyid",
+        "type" : [ "string", "object" ]
+      },
+      "SnapshotId" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-ebsinstanceblockdevicespecification.html#cfn-imagebuilder-imagerecipe-ebsinstanceblockdevicespecification-snapshotid",
+        "type" : [ "string", "object" ]
+      },
+      "VolumeSize" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-ebsinstanceblockdevicespecification.html#cfn-imagebuilder-imagerecipe-ebsinstanceblockdevicespecification-volumesize",
+        "type" : [ "integer", "object" ]
+      },
+      "VolumeType" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-ebsinstanceblockdevicespecification.html#cfn-imagebuilder-imagerecipe-ebsinstanceblockdevicespecification-volumetype",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_ImageBuilder_ImageRecipe_InstanceBlockDeviceMapping" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-instanceblockdevicemapping.html",
+    "properties" : {
+      "DeviceName" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-instanceblockdevicemapping.html#cfn-imagebuilder-imagerecipe-instanceblockdevicemapping-devicename",
+        "type" : [ "string", "object" ]
+      },
+      "VirtualName" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-instanceblockdevicemapping.html#cfn-imagebuilder-imagerecipe-instanceblockdevicemapping-virtualname",
+        "type" : [ "string", "object" ]
+      },
+      "NoDevice" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-instanceblockdevicemapping.html#cfn-imagebuilder-imagerecipe-instanceblockdevicemapping-nodevice",
+        "type" : [ "string", "object" ]
+      },
+      "Ebs" : {
+        "$ref" : "#/definitions/AWS_ImageBuilder_ImageRecipe_EbsInstanceBlockDeviceSpecification"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_ImageBuilder_InfrastructureConfiguration_Logging" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-infrastructureconfiguration-logging.html",
+    "properties" : {
+      "S3Logs" : {
+        "$ref" : "#/definitions/AWS_ImageBuilder_InfrastructureConfiguration_S3Logs"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_ImageBuilder_InfrastructureConfiguration_S3Logs" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-infrastructureconfiguration-s3logs.html",
+    "properties" : {
+      "S3BucketName" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-infrastructureconfiguration-s3logs.html#cfn-imagebuilder-infrastructureconfiguration-s3logs-s3bucketname",
+        "type" : [ "string", "object" ]
+      },
+      "S3KeyPrefix" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-infrastructureconfiguration-s3logs.html#cfn-imagebuilder-infrastructureconfiguration-s3logs-s3keyprefix",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "additionalProperties" : false
+  },
   "AWS_IoT1Click_Project_DeviceTemplate" : {
     "type" : "object",
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iot1click-project-devicetemplate.html",
@@ -55873,6 +56364,16 @@
         }, {
           "$ref" : "#/definitions/AWS_IAM_UserToGroupAddition"
         }, {
+          "$ref" : "#/definitions/AWS_ImageBuilder_Component"
+        }, {
+          "$ref" : "#/definitions/AWS_ImageBuilder_DistributionConfiguration"
+        }, {
+          "$ref" : "#/definitions/AWS_ImageBuilder_ImagePipeline"
+        }, {
+          "$ref" : "#/definitions/AWS_ImageBuilder_ImageRecipe"
+        }, {
+          "$ref" : "#/definitions/AWS_ImageBuilder_InfrastructureConfiguration"
+        }, {
           "$ref" : "#/definitions/AWS_Inspector_AssessmentTarget"
         }, {
           "$ref" : "#/definitions/AWS_Inspector_AssessmentTemplate"
@@ -56350,7 +56851,7 @@
       "$ref": "#/definitions/resources"
     }
   },
-  "description": "CFN JSON specification generated from version 12.2.0",
+  "description": "CFN JSON specification generated from version 12.3.0",
   "required": [
     "Resources"
   ]


### PR DESCRIPTION
https://github.com/aws-cloudformation/aws-cloudformation-template-schema/issues/32

https://github.com/aws-cloudformation/aws-cloudformation-template-schema/blob/master/docs/tool/instructions.md

as described in https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code/pull/76

---

[still running into:](https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code/pull/85)

```java
aws.cfn.codegen.CfnSpecificationException: Json referenced but not defined in AWS::ResourceGroups::Group
	at aws.cfn.codegen.CfnSpecification.lambda$validate$0(CfnSpecification.java:35) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.Optional.ifPresent(Optional.java:176) ~[?:?]
	at aws.cfn.codegen.CfnSpecification.lambda$validate$1(CfnSpecification.java:32) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.LinkedHashMap.forEach(LinkedHashMap.java:723) ~[?:?]
	at aws.cfn.codegen.CfnSpecification.lambda$validate$2(CfnSpecification.java:30) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.LinkedHashMap.forEach(LinkedHashMap.java:723) ~[?:?]
	at aws.cfn.codegen.CfnSpecification.validate(CfnSpecification.java:28) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Codegen.loadSpecification(Codegen.java:66) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Codegen.lambda$generate$7(Codegen.java:199) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195) [?:?]
	at java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1694) [?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) [?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) [?:?]
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) [?:?]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) [?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) [?:?]
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497) [?:?]
	at aws.cfn.codegen.json.Codegen.generate(Codegen.java:209) [aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Main.execute(Main.java:81) [aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Main.main(Main.java:89) [aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
Exception in thread "main" java.lang.RuntimeException: aws.cfn.codegen.CfnSpecificationException: Json referenced but not defined in AWS::ResourceGroups::Group
	at aws.cfn.codegen.json.Codegen.lambda$generate$7(Codegen.java:206)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1694)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
	at aws.cfn.codegen.json.Codegen.generate(Codegen.java:209)
	at aws.cfn.codegen.json.Main.execute(Main.java:81)
	at aws.cfn.codegen.json.Main.main(Main.java:89)
Caused by: aws.cfn.codegen.CfnSpecificationException: Json referenced but not defined in AWS::ResourceGroups::Group
	at aws.cfn.codegen.CfnSpecification.lambda$validate$0(CfnSpecification.java:35)
	at java.base/java.util.Optional.ifPresent(Optional.java:176)
	at aws.cfn.codegen.CfnSpecification.lambda$validate$1(CfnSpecification.java:32)
	at java.base/java.util.LinkedHashMap.forEach(LinkedHashMap.java:723)
	at aws.cfn.codegen.CfnSpecification.lambda$validate$2(CfnSpecification.java:30)
	at java.base/java.util.LinkedHashMap.forEach(LinkedHashMap.java:723)
	at aws.cfn.codegen.CfnSpecification.validate(CfnSpecification.java:28)
	at aws.cfn.codegen.json.Codegen.loadSpecification(Codegen.java:66)
	at aws.cfn.codegen.json.Codegen.lambda$generate$7(Codegen.java:199)
	... 11 more
```

so I switched [`AWS::ResourceGroups::Group.Tags`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-resourcegroups-group.html#cfn-resourcegroups-group-tags) from `"ItemType": "Json"` to `"ItemType": "Tag"` in the [CloudFormation Resource Specification](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html) and used [that](https://gist.githubusercontent.com/PatMyron/b05935a62fac1c136a2b6809e0e1b670/raw/c5786ee5fdf43a2c8952e257ae055d3ac176607a/CloudFormationResourceSpecification.json) instead:

```shell
aws-cloudformation-template-schema $ git diff
diff --git a/src/main/resources/config.yml b/src/main/resources/config.yml
index f58bb07..b26a11a 100644
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -33,7 +33,7 @@ settings:
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html
 specifications:
   # US Region
-  us-east-1: https://d1uauaxba7bl26.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json
+  us-east-1: https://gist.githubusercontent.com/PatMyron/b05935a62fac1c136a2b6809e0e1b670/raw/c5786ee5fdf43a2c8952e257ae055d3ac176607a/CloudFormationResourceSpecification.json
```