### PR TITLE
removing copyright dates

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 AWS Cfn Lint Visual Studio Code
-Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License").
 You may not use this file except in compliance with the License.

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
-Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License").
 You may not use this file except in compliance with the License.


### PR DESCRIPTION
time is a social construct

(more importantly in line with [the legal guidance for 2020 onwards](https://w.amazon.com/bin/view/Open_Source/LicensingForGitHubProjects/#Copyright_Dates_for_Amazon-created_Open_Source))

```shell
aws-cfn-lint-visual-studio-code $ git grep -hiErl 'copyright' * | xargs gsed -i 's/Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved/Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved/g'
```

[Linter PR](https://github.com/aws-cloudformation/cfn-python-lint/pull/1528)