### PR TITLE
CloudFormation Template Schema 16.2.0

### DIFF
--- a/schema/all-spec.json
+++ b/schema/all-spec.json
@@ -543,8 +543,15 @@
           "Configuration" : {
             "$ref" : "#/definitions/AWS_AmazonMQ_Broker_ConfigurationId"
           },
+          "AuthenticationStrategy" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amazonmq-broker.html#cfn-amazonmq-broker-authenticationstrategy",
+            "type" : [ "string", "object" ]
+          },
           "MaintenanceWindowStartTime" : {
             "$ref" : "#/definitions/AWS_AmazonMQ_Broker_MaintenanceWindow"
+          },
+          "LdapMetadata" : {
+            "$ref" : "#/definitions/AWS_AmazonMQ_Broker_LdapMetadata"
           },
           "HostInstanceType" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amazonmq-broker.html#cfn-amazonmq-broker-hostinstancetype",
@@ -576,6 +583,9 @@
           "BrokerName" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amazonmq-broker.html#cfn-amazonmq-broker-brokername",
             "type" : [ "string", "object" ]
+          },
+          "LdapServerMetadata" : {
+            "$ref" : "#/definitions/AWS_AmazonMQ_Broker_LdapServerMetadata"
           },
           "DeploymentMode" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amazonmq-broker.html#cfn-amazonmq-broker-deploymentmode",
@@ -2026,6 +2036,45 @@
     "required" : [ "Type" ],
     "additionalProperties" : false
   },
+  "AWS_ApiGatewayV2_ApiGatewayManagedOverrides" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-apigatewaymanagedoverrides.html",
+    "properties" : {
+      "Type" : {
+        "description" : "Type of resource equals only AWS::ApiGatewayV2::ApiGatewayManagedOverrides",
+        "type" : "string",
+        "enum" : [ "AWS::ApiGatewayV2::ApiGatewayManagedOverrides" ]
+      },
+      "Properties" : {
+        "type" : "object",
+        "properties" : {
+          "Integration" : {
+            "$ref" : "#/definitions/AWS_ApiGatewayV2_ApiGatewayManagedOverrides_IntegrationOverrides"
+          },
+          "Stage" : {
+            "$ref" : "#/definitions/AWS_ApiGatewayV2_ApiGatewayManagedOverrides_StageOverrides"
+          },
+          "ApiId" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-apigatewaymanagedoverrides.html#cfn-apigatewayv2-apigatewaymanagedoverrides-apiid",
+            "type" : [ "string", "object" ]
+          },
+          "Route" : {
+            "$ref" : "#/definitions/AWS_ApiGatewayV2_ApiGatewayManagedOverrides_RouteOverrides"
+          }
+        },
+        "required" : [ "ApiId" ],
+        "additionalProperties" : false
+      },
+      "DependsOn" : {
+        "type" : [ "string", "array" ],
+        "items" : {
+          "type" : "string"
+        }
+      }
+    },
+    "required" : [ "Type", "Properties" ],
+    "additionalProperties" : false
+  },
   "AWS_ApiGatewayV2_ApiMapping" : {
     "type" : "object",
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-apimapping.html",
@@ -2586,6 +2635,56 @@
           }
         },
         "required" : [ "StageName", "ApiId" ],
+        "additionalProperties" : false
+      },
+      "DependsOn" : {
+        "type" : [ "string", "array" ],
+        "items" : {
+          "type" : "string"
+        }
+      }
+    },
+    "required" : [ "Type", "Properties" ],
+    "additionalProperties" : false
+  },
+  "AWS_ApiGatewayV2_VpcLink" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-vpclink.html",
+    "properties" : {
+      "Type" : {
+        "description" : "Type of resource equals only AWS::ApiGatewayV2::VpcLink",
+        "type" : "string",
+        "enum" : [ "AWS::ApiGatewayV2::VpcLink" ]
+      },
+      "Properties" : {
+        "type" : "object",
+        "properties" : {
+          "SubnetIds" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-vpclink.html#cfn-apigatewayv2-vpclink-subnetids",
+            "type" : "array",
+            "items" : {
+              "type" : [ "string", "object" ]
+            },
+            "minItems" : 0
+          },
+          "SecurityGroupIds" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-vpclink.html#cfn-apigatewayv2-vpclink-securitygroupids",
+            "type" : "array",
+            "items" : {
+              "type" : [ "string", "object" ]
+            },
+            "minItems" : 0
+          },
+          "Tags" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-vpclink.html#cfn-apigatewayv2-vpclink-tags",
+            "type" : [ "object" ]
+          },
+          "Name" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-vpclink.html#cfn-apigatewayv2-vpclink-name",
+            "type" : [ "string", "object" ]
+          }
+        },
+        "required" : [ "SubnetIds", "Name" ],
         "additionalProperties" : false
       },
       "DependsOn" : {
@@ -6772,6 +6871,10 @@
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codestarconnections-connection.html#cfn-codestarconnections-connection-providertype",
             "type" : [ "string", "object" ]
           },
+          "HostArn" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codestarconnections-connection.html#cfn-codestarconnections-connection-hostarn",
+            "type" : [ "string", "object" ]
+          },
           "Tags" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codestarconnections-connection.html#cfn-codestarconnections-connection-tags",
             "type" : "array",
@@ -6781,7 +6884,7 @@
             "minItems" : 0
           }
         },
-        "required" : [ "ConnectionName", "ProviderType" ],
+        "required" : [ "ConnectionName" ],
         "additionalProperties" : false
       },
       "DependsOn" : {
@@ -9888,9 +9991,17 @@
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-flowlog.html#cfn-ec2-flowlog-logdestinationtype",
             "type" : [ "string", "object" ]
           },
+          "LogFormat" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-flowlog.html#cfn-ec2-flowlog-logformat",
+            "type" : [ "string", "object" ]
+          },
           "LogGroupName" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-flowlog.html#cfn-ec2-flowlog-loggroupname",
             "type" : [ "string", "object" ]
+          },
+          "MaxAggregationInterval" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-flowlog.html#cfn-ec2-flowlog-maxaggregationinterval",
+            "type" : [ "integer", "object" ]
           },
           "ResourceId" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-flowlog.html#cfn-ec2-flowlog-resourceid",
@@ -9899,6 +10010,14 @@
           "ResourceType" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-flowlog.html#cfn-ec2-flowlog-resourcetype",
             "type" : [ "string", "object" ]
+          },
+          "Tags" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-flowlog.html#cfn-ec2-flowlog-tags",
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/Tag"
+            },
+            "minItems" : 0
           },
           "TrafficType" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-flowlog.html#cfn-ec2-flowlog-traffictype",
@@ -12716,6 +12835,10 @@
       "Properties" : {
         "type" : "object",
         "properties" : {
+          "Family" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-family",
+            "type" : [ "string", "object" ]
+          },
           "ContainerDefinitions" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-containerdefinitions",
             "type" : "array",
@@ -12733,10 +12856,6 @@
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-executionrolearn",
             "type" : [ "string", "object" ]
           },
-          "Family" : {
-            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-family",
-            "type" : [ "string", "object" ]
-          },
           "InferenceAccelerators" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-inferenceaccelerators",
             "type" : "array",
@@ -12746,20 +12865,12 @@
             "uniqueItems" : true,
             "minItems" : 0
           },
-          "IpcMode" : {
-            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-ipcmode",
-            "type" : [ "string", "object" ]
-          },
           "Memory" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-memory",
             "type" : [ "string", "object" ]
           },
           "NetworkMode" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-networkmode",
-            "type" : [ "string", "object" ]
-          },
-          "PidMode" : {
-            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-pidmode",
             "type" : [ "string", "object" ]
           },
           "PlacementConstraints" : {
@@ -12783,14 +12894,6 @@
             "uniqueItems" : true,
             "minItems" : 0
           },
-          "Tags" : {
-            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-tags",
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/definitions/Tag"
-            },
-            "minItems" : 0
-          },
           "TaskRoleArn" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-taskrolearn",
             "type" : [ "string", "object" ]
@@ -12803,6 +12906,26 @@
             },
             "uniqueItems" : true,
             "minItems" : 0
+          },
+          "PidMode" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-pidmode",
+            "type" : [ "string", "object" ]
+          },
+          "IpcMode" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-ipcmode",
+            "type" : [ "string", "object" ]
+          },
+          "Tags" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-tags",
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/Tag"
+            },
+            "minItems" : 0
+          },
+          "TaskDefinitionStatus" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-taskdefinitionstatus",
+            "type" : [ "string", "object" ]
           }
         },
         "additionalProperties" : false
@@ -12991,6 +13114,9 @@
           "FileSystemPolicy" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-filesystem.html#cfn-efs-filesystem-filesystempolicy",
             "type" : [ "object" ]
+          },
+          "BackupPolicy" : {
+            "$ref" : "#/definitions/AWS_EFS_FileSystem_BackupPolicy"
           }
         },
         "additionalProperties" : false
@@ -18271,6 +18397,15 @@
           "SnsTopicArn" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html#cfn-imagebuilder-infrastructureconfiguration-snstopicarn",
             "type" : [ "string", "object" ]
+          },
+          "ResourceTags" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html#cfn-imagebuilder-infrastructureconfiguration-resourcetags",
+            "type" : "object",
+            "patternProperties" : {
+              "[a-zA-Z0-9]+" : {
+                "type" : [ "string", "object" ]
+              }
+            }
           },
           "Tags" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html#cfn-imagebuilder-infrastructureconfiguration-tags",
@@ -27277,6 +27412,9 @@
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-rotationschedule.html#cfn-secretsmanager-rotationschedule-secretid",
             "type" : [ "string", "object" ]
           },
+          "HostedRotationLambda" : {
+            "$ref" : "#/definitions/AWS_SecretsManager_RotationSchedule_HostedRotationLambda"
+          },
           "RotationLambdaARN" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-rotationschedule.html#cfn-secretsmanager-rotationschedule-rotationlambdaarn",
             "type" : [ "string", "object" ]
@@ -28420,6 +28558,9 @@
           "StateMachineType" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html#cfn-stepfunctions-statemachine-statemachinetype",
             "type" : [ "string", "object" ]
+          },
+          "TracingConfiguration" : {
+            "$ref" : "#/definitions/AWS_StepFunctions_StateMachine_TracingConfiguration"
           }
         },
         "required" : [ "RoleArn" ],
@@ -29899,6 +30040,96 @@
     "required" : [ "UseAwsOwnedKey" ],
     "additionalProperties" : false
   },
+  "AWS_AmazonMQ_Broker_InterBrokerCred" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-interbrokercred.html",
+    "properties" : {
+      "Username" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-interbrokercred.html#cfn-amazonmq-broker-interbrokercred-username",
+        "type" : [ "string", "object" ]
+      },
+      "Password" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-interbrokercred.html#cfn-amazonmq-broker-interbrokercred-password",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "required" : [ "Username", "Password" ],
+    "additionalProperties" : false
+  },
+  "AWS_AmazonMQ_Broker_LdapMetadata" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-ldapmetadata.html",
+    "properties" : {
+      "InterBrokerCreds" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-ldapmetadata.html#cfn-amazonmq-broker-ldapmetadata-interbrokercreds",
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/definitions/AWS_AmazonMQ_Broker_InterBrokerCred"
+        },
+        "minItems" : 0
+      },
+      "ServerMetadata" : {
+        "$ref" : "#/definitions/AWS_AmazonMQ_Broker_ServerMetadata"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_AmazonMQ_Broker_LdapServerMetadata" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-ldapservermetadata.html",
+    "properties" : {
+      "Hosts" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-ldapservermetadata.html#cfn-amazonmq-broker-ldapservermetadata-hosts",
+        "type" : "array",
+        "items" : {
+          "type" : [ "string", "object" ]
+        },
+        "minItems" : 0
+      },
+      "UserRoleName" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-ldapservermetadata.html#cfn-amazonmq-broker-ldapservermetadata-userrolename",
+        "type" : [ "string", "object" ]
+      },
+      "UserSearchMatching" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-ldapservermetadata.html#cfn-amazonmq-broker-ldapservermetadata-usersearchmatching",
+        "type" : [ "string", "object" ]
+      },
+      "RoleName" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-ldapservermetadata.html#cfn-amazonmq-broker-ldapservermetadata-rolename",
+        "type" : [ "string", "object" ]
+      },
+      "UserBase" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-ldapservermetadata.html#cfn-amazonmq-broker-ldapservermetadata-userbase",
+        "type" : [ "string", "object" ]
+      },
+      "UserSearchSubtree" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-ldapservermetadata.html#cfn-amazonmq-broker-ldapservermetadata-usersearchsubtree",
+        "type" : [ "boolean", "object" ]
+      },
+      "RoleSearchMatching" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-ldapservermetadata.html#cfn-amazonmq-broker-ldapservermetadata-rolesearchmatching",
+        "type" : [ "string", "object" ]
+      },
+      "ServiceAccountUsername" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-ldapservermetadata.html#cfn-amazonmq-broker-ldapservermetadata-serviceaccountusername",
+        "type" : [ "string", "object" ]
+      },
+      "RoleBase" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-ldapservermetadata.html#cfn-amazonmq-broker-ldapservermetadata-rolebase",
+        "type" : [ "string", "object" ]
+      },
+      "ServiceAccountPassword" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-ldapservermetadata.html#cfn-amazonmq-broker-ldapservermetadata-serviceaccountpassword",
+        "type" : [ "string", "object" ]
+      },
+      "RoleSearchSubtree" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-ldapservermetadata.html#cfn-amazonmq-broker-ldapservermetadata-rolesearchsubtree",
+        "type" : [ "boolean", "object" ]
+      }
+    },
+    "required" : [ "Hosts", "UserSearchMatching", "UserBase", "RoleSearchMatching", "ServiceAccountUsername", "RoleBase", "ServiceAccountPassword" ],
+    "additionalProperties" : false
+  },
   "AWS_AmazonMQ_Broker_LogList" : {
     "type" : "object",
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-loglist.html",
@@ -29932,6 +30163,62 @@
       }
     },
     "required" : [ "DayOfWeek", "TimeOfDay", "TimeZone" ],
+    "additionalProperties" : false
+  },
+  "AWS_AmazonMQ_Broker_ServerMetadata" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-servermetadata.html",
+    "properties" : {
+      "Hosts" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-servermetadata.html#cfn-amazonmq-broker-servermetadata-hosts",
+        "type" : "array",
+        "items" : {
+          "type" : [ "string", "object" ]
+        },
+        "minItems" : 0
+      },
+      "UserRoleName" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-servermetadata.html#cfn-amazonmq-broker-servermetadata-userrolename",
+        "type" : [ "string", "object" ]
+      },
+      "UserSearchMatching" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-servermetadata.html#cfn-amazonmq-broker-servermetadata-usersearchmatching",
+        "type" : [ "string", "object" ]
+      },
+      "RoleName" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-servermetadata.html#cfn-amazonmq-broker-servermetadata-rolename",
+        "type" : [ "string", "object" ]
+      },
+      "UserBase" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-servermetadata.html#cfn-amazonmq-broker-servermetadata-userbase",
+        "type" : [ "string", "object" ]
+      },
+      "UserSearchSubtree" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-servermetadata.html#cfn-amazonmq-broker-servermetadata-usersearchsubtree",
+        "type" : [ "boolean", "object" ]
+      },
+      "RoleSearchMatching" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-servermetadata.html#cfn-amazonmq-broker-servermetadata-rolesearchmatching",
+        "type" : [ "string", "object" ]
+      },
+      "ServiceAccountUsername" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-servermetadata.html#cfn-amazonmq-broker-servermetadata-serviceaccountusername",
+        "type" : [ "string", "object" ]
+      },
+      "RoleBase" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-servermetadata.html#cfn-amazonmq-broker-servermetadata-rolebase",
+        "type" : [ "string", "object" ]
+      },
+      "ServiceAccountPassword" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-servermetadata.html#cfn-amazonmq-broker-servermetadata-serviceaccountpassword",
+        "type" : [ "string", "object" ]
+      },
+      "RoleSearchSubtree" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-servermetadata.html#cfn-amazonmq-broker-servermetadata-rolesearchsubtree",
+        "type" : [ "boolean", "object" ]
+      }
+    },
+    "required" : [ "Hosts", "UserSearchMatching", "UserBase", "RoleSearchMatching", "ServiceAccountUsername", "RoleBase", "ServiceAccountPassword" ],
     "additionalProperties" : false
   },
   "AWS_AmazonMQ_Broker_TagsEntry" : {
@@ -30847,6 +31134,131 @@
           "type" : [ "string", "object" ]
         },
         "minItems" : 0
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_ApiGatewayV2_ApiGatewayManagedOverrides_AccessLogSettings" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-accesslogsettings.html",
+    "properties" : {
+      "Format" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-accesslogsettings.html#cfn-apigatewayv2-apigatewaymanagedoverrides-accesslogsettings-format",
+        "type" : [ "string", "object" ]
+      },
+      "DestinationArn" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-accesslogsettings.html#cfn-apigatewayv2-apigatewaymanagedoverrides-accesslogsettings-destinationarn",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_ApiGatewayV2_ApiGatewayManagedOverrides_IntegrationOverrides" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-integrationoverrides.html",
+    "properties" : {
+      "Description" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-integrationoverrides.html#cfn-apigatewayv2-apigatewaymanagedoverrides-integrationoverrides-description",
+        "type" : [ "string", "object" ]
+      },
+      "PayloadFormatVersion" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-integrationoverrides.html#cfn-apigatewayv2-apigatewaymanagedoverrides-integrationoverrides-payloadformatversion",
+        "type" : [ "string", "object" ]
+      },
+      "TimeoutInMillis" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-integrationoverrides.html#cfn-apigatewayv2-apigatewaymanagedoverrides-integrationoverrides-timeoutinmillis",
+        "type" : [ "integer", "object" ]
+      },
+      "IntegrationMethod" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-integrationoverrides.html#cfn-apigatewayv2-apigatewaymanagedoverrides-integrationoverrides-integrationmethod",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_ApiGatewayV2_ApiGatewayManagedOverrides_RouteOverrides" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-routeoverrides.html",
+    "properties" : {
+      "Target" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-routeoverrides.html#cfn-apigatewayv2-apigatewaymanagedoverrides-routeoverrides-target",
+        "type" : [ "string", "object" ]
+      },
+      "AuthorizerId" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-routeoverrides.html#cfn-apigatewayv2-apigatewaymanagedoverrides-routeoverrides-authorizerid",
+        "type" : [ "string", "object" ]
+      },
+      "OperationName" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-routeoverrides.html#cfn-apigatewayv2-apigatewaymanagedoverrides-routeoverrides-operationname",
+        "type" : [ "string", "object" ]
+      },
+      "AuthorizationScopes" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-routeoverrides.html#cfn-apigatewayv2-apigatewaymanagedoverrides-routeoverrides-authorizationscopes",
+        "type" : "array",
+        "items" : {
+          "type" : [ "string", "object" ]
+        },
+        "minItems" : 0
+      },
+      "AuthorizationType" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-routeoverrides.html#cfn-apigatewayv2-apigatewaymanagedoverrides-routeoverrides-authorizationtype",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_ApiGatewayV2_ApiGatewayManagedOverrides_RouteSettings" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-routesettings.html",
+    "properties" : {
+      "LoggingLevel" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-routesettings.html#cfn-apigatewayv2-apigatewaymanagedoverrides-routesettings-logginglevel",
+        "type" : [ "string", "object" ]
+      },
+      "DataTraceEnabled" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-routesettings.html#cfn-apigatewayv2-apigatewaymanagedoverrides-routesettings-datatraceenabled",
+        "type" : [ "boolean", "object" ]
+      },
+      "ThrottlingBurstLimit" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-routesettings.html#cfn-apigatewayv2-apigatewaymanagedoverrides-routesettings-throttlingburstlimit",
+        "type" : [ "integer", "object" ]
+      },
+      "DetailedMetricsEnabled" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-routesettings.html#cfn-apigatewayv2-apigatewaymanagedoverrides-routesettings-detailedmetricsenabled",
+        "type" : [ "boolean", "object" ]
+      },
+      "ThrottlingRateLimit" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-routesettings.html#cfn-apigatewayv2-apigatewaymanagedoverrides-routesettings-throttlingratelimit",
+        "type" : [ "number", "object" ]
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_ApiGatewayV2_ApiGatewayManagedOverrides_StageOverrides" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-stageoverrides.html",
+    "properties" : {
+      "Description" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-stageoverrides.html#cfn-apigatewayv2-apigatewaymanagedoverrides-stageoverrides-description",
+        "type" : [ "string", "object" ]
+      },
+      "AccessLogSettings" : {
+        "$ref" : "#/definitions/AWS_ApiGatewayV2_ApiGatewayManagedOverrides_AccessLogSettings"
+      },
+      "AutoDeploy" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-stageoverrides.html#cfn-apigatewayv2-apigatewaymanagedoverrides-stageoverrides-autodeploy",
+        "type" : [ "boolean", "object" ]
+      },
+      "RouteSettings" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-stageoverrides.html#cfn-apigatewayv2-apigatewaymanagedoverrides-stageoverrides-routesettings",
+        "type" : [ "object" ]
+      },
+      "StageVariables" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-apigatewaymanagedoverrides-stageoverrides.html#cfn-apigatewayv2-apigatewaymanagedoverrides-stageoverrides-stagevariables",
+        "type" : [ "object" ]
+      },
+      "DefaultRouteSettings" : {
+        "$ref" : "#/definitions/AWS_ApiGatewayV2_ApiGatewayManagedOverrides_RouteSettings"
       }
     },
     "additionalProperties" : false
@@ -34450,9 +34862,17 @@
       "ForwardedValues" : {
         "$ref" : "#/definitions/AWS_CloudFront_Distribution_ForwardedValues"
       },
+      "OriginRequestPolicyId" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-cachebehavior.html#cfn-cloudfront-distribution-cachebehavior-originrequestpolicyid",
+        "type" : [ "string", "object" ]
+      },
       "MinTTL" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-cachebehavior.html#cfn-cloudfront-distribution-cachebehavior-minttl",
         "type" : [ "number", "object" ]
+      },
+      "CachePolicyId" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-cachebehavior.html#cfn-cloudfront-distribution-cachebehavior-cachepolicyid",
+        "type" : [ "string", "object" ]
       },
       "MaxTTL" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-cachebehavior.html#cfn-cloudfront-distribution-cachebehavior-maxttl",
@@ -34605,9 +35025,17 @@
       "ForwardedValues" : {
         "$ref" : "#/definitions/AWS_CloudFront_Distribution_ForwardedValues"
       },
+      "OriginRequestPolicyId" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-defaultcachebehavior.html#cfn-cloudfront-distribution-defaultcachebehavior-originrequestpolicyid",
+        "type" : [ "string", "object" ]
+      },
       "MinTTL" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-defaultcachebehavior.html#cfn-cloudfront-distribution-defaultcachebehavior-minttl",
         "type" : [ "number", "object" ]
+      },
+      "CachePolicyId" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-defaultcachebehavior.html#cfn-cloudfront-distribution-defaultcachebehavior-cachepolicyid",
+        "type" : [ "string", "object" ]
       },
       "MaxTTL" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-defaultcachebehavior.html#cfn-cloudfront-distribution-defaultcachebehavior-maxttl",
@@ -40422,7 +40850,6 @@
         "items" : {
           "type" : [ "string", "object" ]
         },
-        "uniqueItems" : true,
         "minItems" : 0
       },
       "Cpu" : {
@@ -40435,7 +40862,6 @@
         "items" : {
           "$ref" : "#/definitions/AWS_ECS_TaskDefinition_ContainerDependency"
         },
-        "uniqueItems" : true,
         "minItems" : 0
       },
       "DisableNetworking" : {
@@ -40448,7 +40874,6 @@
         "items" : {
           "type" : [ "string", "object" ]
         },
-        "uniqueItems" : true,
         "minItems" : 0
       },
       "DnsServers" : {
@@ -40457,7 +40882,6 @@
         "items" : {
           "type" : [ "string", "object" ]
         },
-        "uniqueItems" : true,
         "minItems" : 0
       },
       "DockerLabels" : {
@@ -40475,7 +40899,6 @@
         "items" : {
           "type" : [ "string", "object" ]
         },
-        "uniqueItems" : true,
         "minItems" : 0
       },
       "EntryPoint" : {
@@ -40484,7 +40907,6 @@
         "items" : {
           "type" : [ "string", "object" ]
         },
-        "uniqueItems" : true,
         "minItems" : 0
       },
       "Environment" : {
@@ -40506,7 +40928,6 @@
         "items" : {
           "$ref" : "#/definitions/AWS_ECS_TaskDefinition_HostEntry"
         },
-        "uniqueItems" : true,
         "minItems" : 0
       },
       "FirelensConfiguration" : {
@@ -40522,10 +40943,6 @@
       "Image" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-image",
         "type" : [ "string", "object" ]
-      },
-      "Interactive" : {
-        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-interactive",
-        "type" : [ "boolean", "object" ]
       },
       "Links" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-links",
@@ -40576,10 +40993,6 @@
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-privileged",
         "type" : [ "boolean", "object" ]
       },
-      "PseudoTerminal" : {
-        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-pseudoterminal",
-        "type" : [ "boolean", "object" ]
-      },
       "ReadonlyRootFilesystem" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-readonlyrootfilesystem",
         "type" : [ "boolean", "object" ]
@@ -40593,7 +41006,6 @@
         "items" : {
           "$ref" : "#/definitions/AWS_ECS_TaskDefinition_ResourceRequirement"
         },
-        "uniqueItems" : true,
         "minItems" : 0
       },
       "Secrets" : {
@@ -40602,7 +41014,6 @@
         "items" : {
           "$ref" : "#/definitions/AWS_ECS_TaskDefinition_Secret"
         },
-        "uniqueItems" : true,
         "minItems" : 0
       },
       "StartTimeout" : {
@@ -40613,22 +41024,12 @@
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-stoptimeout",
         "type" : [ "integer", "object" ]
       },
-      "SystemControls" : {
-        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-systemcontrols",
-        "type" : "array",
-        "items" : {
-          "$ref" : "#/definitions/AWS_ECS_TaskDefinition_SystemControl"
-        },
-        "uniqueItems" : true,
-        "minItems" : 0
-      },
       "Ulimits" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-ulimits",
         "type" : "array",
         "items" : {
           "$ref" : "#/definitions/AWS_ECS_TaskDefinition_Ulimit"
         },
-        "uniqueItems" : true,
         "minItems" : 0
       },
       "User" : {
@@ -40647,6 +41048,22 @@
       "WorkingDirectory" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-workingdirectory",
         "type" : [ "string", "object" ]
+      },
+      "Interactive" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-interactive",
+        "type" : [ "boolean", "object" ]
+      },
+      "PseudoTerminal" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-pseudoterminal",
+        "type" : [ "boolean", "object" ]
+      },
+      "SystemControls" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-systemcontrols",
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/definitions/AWS_ECS_TaskDefinition_SystemControl"
+        },
+        "minItems" : 0
       }
     },
     "additionalProperties" : false
@@ -40655,16 +41072,15 @@
     "type" : "object",
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdependency.html",
     "properties" : {
-      "Condition" : {
-        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdependency.html#cfn-ecs-taskdefinition-containerdependency-condition",
-        "type" : [ "string", "object" ]
-      },
       "ContainerName" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdependency.html#cfn-ecs-taskdefinition-containerdependency-containername",
         "type" : [ "string", "object" ]
+      },
+      "Condition" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdependency.html#cfn-ecs-taskdefinition-containerdependency-condition",
+        "type" : [ "string", "object" ]
       }
     },
-    "required" : [ "Condition", "ContainerName" ],
     "additionalProperties" : false
   },
   "AWS_ECS_TaskDefinition_Device" : {
@@ -40689,7 +41105,6 @@
         "minItems" : 0
       }
     },
-    "required" : [ "HostPath" ],
     "additionalProperties" : false
   },
   "AWS_ECS_TaskDefinition_DockerVolumeConfiguration" : {
@@ -40733,21 +41148,14 @@
     "type" : "object",
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-firelensconfiguration.html",
     "properties" : {
-      "Options" : {
-        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-firelensconfiguration.html#cfn-ecs-taskdefinition-firelensconfiguration-options",
-        "type" : "object",
-        "patternProperties" : {
-          "[a-zA-Z0-9]+" : {
-            "type" : [ "string", "object" ]
-          }
-        }
-      },
       "Type" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-firelensconfiguration.html#cfn-ecs-taskdefinition-firelensconfiguration-type",
         "type" : [ "string", "object" ]
+      },
+      "Options" : {
+        "$ref" : "#/definitions/AWS_ECS_TaskDefinition_Options"
       }
     },
-    "required" : [ "Type" ],
     "additionalProperties" : false
   },
   "AWS_ECS_TaskDefinition_HealthCheck" : {
@@ -40760,11 +41168,14 @@
         "items" : {
           "type" : [ "string", "object" ]
         },
-        "uniqueItems" : true,
         "minItems" : 0
       },
       "Interval" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-healthcheck.html#cfn-ecs-taskdefinition-healthcheck-interval",
+        "type" : [ "integer", "object" ]
+      },
+      "Timeout" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-healthcheck.html#cfn-ecs-taskdefinition-healthcheck-timeout",
         "type" : [ "integer", "object" ]
       },
       "Retries" : {
@@ -40774,13 +41185,8 @@
       "StartPeriod" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-healthcheck.html#cfn-ecs-taskdefinition-healthcheck-startperiod",
         "type" : [ "integer", "object" ]
-      },
-      "Timeout" : {
-        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-healthcheck.html#cfn-ecs-taskdefinition-healthcheck-timeout",
-        "type" : [ "integer", "object" ]
       }
     },
-    "required" : [ "Command" ],
     "additionalProperties" : false
   },
   "AWS_ECS_TaskDefinition_HostEntry" : {
@@ -40796,7 +41202,6 @@
         "type" : [ "string", "object" ]
       }
     },
-    "required" : [ "Hostname", "IpAddress" ],
     "additionalProperties" : false
   },
   "AWS_ECS_TaskDefinition_HostVolumeProperties" : {
@@ -40835,7 +41240,6 @@
         "items" : {
           "type" : [ "string", "object" ]
         },
-        "uniqueItems" : true,
         "minItems" : 0
       },
       "Drop" : {
@@ -40844,7 +41248,6 @@
         "items" : {
           "type" : [ "string", "object" ]
         },
-        "uniqueItems" : true,
         "minItems" : 0
       }
     },
@@ -40878,7 +41281,6 @@
         "items" : {
           "$ref" : "#/definitions/AWS_ECS_TaskDefinition_Device"
         },
-        "uniqueItems" : true,
         "minItems" : 0
       },
       "InitProcessEnabled" : {
@@ -40903,7 +41305,6 @@
         "items" : {
           "$ref" : "#/definitions/AWS_ECS_TaskDefinition_Tmpfs"
         },
-        "uniqueItems" : true,
         "minItems" : 0
       }
     },
@@ -40918,13 +41319,7 @@
         "type" : [ "string", "object" ]
       },
       "Options" : {
-        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions-logconfiguration.html#cfn-ecs-taskdefinition-containerdefinition-logconfiguration-options",
-        "type" : "object",
-        "patternProperties" : {
-          "[a-zA-Z0-9]+" : {
-            "type" : [ "string", "object" ]
-          }
-        }
+        "$ref" : "#/definitions/AWS_ECS_TaskDefinition_Options"
       },
       "SecretOptions" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions-logconfiguration.html#cfn-ecs-taskdefinition-logconfiguration-secretoptions",
@@ -40932,7 +41327,6 @@
         "items" : {
           "$ref" : "#/definitions/AWS_ECS_TaskDefinition_Secret"
         },
-        "uniqueItems" : true,
         "minItems" : 0
       }
     },
@@ -40956,6 +41350,12 @@
         "type" : [ "string", "object" ]
       }
     },
+    "additionalProperties" : false
+  },
+  "AWS_ECS_TaskDefinition_Options" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-options.html",
+    "properties" : { },
     "additionalProperties" : false
   },
   "AWS_ECS_TaskDefinition_PortMapping" : {
@@ -41058,19 +41458,18 @@
         "type" : [ "string", "object" ]
       }
     },
-    "required" : [ "Namespace", "Value" ],
     "additionalProperties" : false
   },
   "AWS_ECS_TaskDefinition_TaskDefinitionPlacementConstraint" : {
     "type" : "object",
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-taskdefinitionplacementconstraint.html",
     "properties" : {
-      "Expression" : {
-        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-taskdefinitionplacementconstraint.html#cfn-ecs-taskdefinition-taskdefinitionplacementconstraint-expression",
-        "type" : [ "string", "object" ]
-      },
       "Type" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-taskdefinitionplacementconstraint.html#cfn-ecs-taskdefinition-taskdefinitionplacementconstraint-type",
+        "type" : [ "string", "object" ]
+      },
+      "Expression" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-taskdefinitionplacementconstraint.html#cfn-ecs-taskdefinition-taskdefinitionplacementconstraint-expression",
         "type" : [ "string", "object" ]
       }
     },
@@ -41091,7 +41490,6 @@
         "items" : {
           "type" : [ "string", "object" ]
         },
-        "uniqueItems" : true,
         "minItems" : 0
       },
       "Size" : {
@@ -41324,6 +41722,18 @@
         "$ref" : "#/definitions/AWS_EFS_AccessPoint_CreationInfo"
       }
     },
+    "additionalProperties" : false
+  },
+  "AWS_EFS_FileSystem_BackupPolicy" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-efs-filesystem-backuppolicy.html",
+    "properties" : {
+      "Status" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-efs-filesystem-backuppolicy.html#cfn-efs-filesystem-backuppolicy-status",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "required" : [ "Status" ],
     "additionalProperties" : false
   },
   "AWS_EFS_FileSystem_ElasticFileSystemTag" : {
@@ -46783,6 +47193,7 @@
         "minItems" : 0
       }
     },
+    "required" : [ "Region" ],
     "additionalProperties" : false
   },
   "AWS_ImageBuilder_Image_ImageTestsConfiguration" : {
@@ -56195,6 +56606,42 @@
     "required" : [ "NotificationTopicArn" ],
     "additionalProperties" : false
   },
+  "AWS_SecretsManager_RotationSchedule_HostedRotationLambda" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-secretsmanager-rotationschedule-hostedrotationlambda.html",
+    "properties" : {
+      "RotationType" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-secretsmanager-rotationschedule-hostedrotationlambda.html#cfn-secretsmanager-rotationschedule-hostedrotationlambda-rotationtype",
+        "type" : [ "string", "object" ]
+      },
+      "RotationLambdaName" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-secretsmanager-rotationschedule-hostedrotationlambda.html#cfn-secretsmanager-rotationschedule-hostedrotationlambda-rotationlambdaname",
+        "type" : [ "string", "object" ]
+      },
+      "KmsKeyArn" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-secretsmanager-rotationschedule-hostedrotationlambda.html#cfn-secretsmanager-rotationschedule-hostedrotationlambda-kmskeyarn",
+        "type" : [ "string", "object" ]
+      },
+      "MasterSecretArn" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-secretsmanager-rotationschedule-hostedrotationlambda.html#cfn-secretsmanager-rotationschedule-hostedrotationlambda-mastersecretarn",
+        "type" : [ "string", "object" ]
+      },
+      "VpcSecurityGroupIds" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-secretsmanager-rotationschedule-hostedrotationlambda.html#cfn-secretsmanager-rotationschedule-hostedrotationlambda-vpcsecuritygroupids",
+        "type" : [ "string", "object" ]
+      },
+      "MasterSecretKmsKeyArn" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-secretsmanager-rotationschedule-hostedrotationlambda.html#cfn-secretsmanager-rotationschedule-hostedrotationlambda-mastersecretkmskeyarn",
+        "type" : [ "string", "object" ]
+      },
+      "VpcSubnetIds" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-secretsmanager-rotationschedule-hostedrotationlambda.html#cfn-secretsmanager-rotationschedule-hostedrotationlambda-vpcsubnetids",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "required" : [ "RotationType" ],
+    "additionalProperties" : false
+  },
   "AWS_SecretsManager_RotationSchedule_RotationRules" : {
     "type" : "object",
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-secretsmanager-rotationschedule-rotationrules.html",
@@ -56510,6 +56957,18 @@
       }
     },
     "required" : [ "Value", "Key" ],
+    "additionalProperties" : false
+  },
+  "AWS_StepFunctions_StateMachine_TracingConfiguration" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-tracingconfiguration.html",
+    "properties" : {
+      "Enabled" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-tracingconfiguration.html#cfn-stepfunctions-statemachine-tracingconfiguration-enabled",
+        "type" : [ "boolean", "object" ]
+      }
+    },
+    "required" : [ "Enabled" ],
     "additionalProperties" : false
   },
   "AWS_Synthetics_Canary_Code" : {
@@ -58451,6 +58910,8 @@
         }, {
           "$ref" : "#/definitions/AWS_ApiGatewayV2_Api"
         }, {
+          "$ref" : "#/definitions/AWS_ApiGatewayV2_ApiGatewayManagedOverrides"
+        }, {
           "$ref" : "#/definitions/AWS_ApiGatewayV2_ApiMapping"
         }, {
           "$ref" : "#/definitions/AWS_ApiGatewayV2_Authorizer"
@@ -58470,6 +58931,8 @@
           "$ref" : "#/definitions/AWS_ApiGatewayV2_RouteResponse"
         }, {
           "$ref" : "#/definitions/AWS_ApiGatewayV2_Stage"
+        }, {
+          "$ref" : "#/definitions/AWS_ApiGatewayV2_VpcLink"
         }, {
           "$ref" : "#/definitions/AWS_AppConfig_Application"
         }, {
@@ -59532,7 +59995,7 @@
       "$ref": "#/definitions/resources"
     }
   },
-  "description": "CFN JSON specification generated from version 16.1.0",
+  "description": "CFN JSON specification generated from version 16.2.0",
   "required": [
     "Resources"
   ]


### PR DESCRIPTION
https://github.com/aws-cloudformation/aws-cloudformation-template-schema/issues/32

https://github.com/aws-cloudformation/aws-cloudformation-template-schema/blob/master/docs/tool/instructions.md

as described in https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code/pull/76

---

[reverted this Dependabot upgrade locally](https://github.com/aws-cloudformation/aws-cloudformation-template-schema/pull/44#issuecomment-652625502)

[still running into:](https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code/pull/85)

```java
aws.cfn.codegen.CfnSpecificationException: ParameterValues referenced but not defined in AWS::SSM::Association
	at aws.cfn.codegen.CfnSpecification.lambda$validate$0(CfnSpecification.java:35) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.Optional.ifPresent(Optional.java:176) ~[?:?]
	at aws.cfn.codegen.CfnSpecification.lambda$validate$1(CfnSpecification.java:32) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.LinkedHashMap.forEach(LinkedHashMap.java:723) ~[?:?]
	at aws.cfn.codegen.CfnSpecification.lambda$validate$2(CfnSpecification.java:30) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.LinkedHashMap.forEach(LinkedHashMap.java:723) ~[?:?]
	at aws.cfn.codegen.CfnSpecification.validate(CfnSpecification.java:28) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Codegen.loadSpecification(Codegen.java:66) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Codegen.lambda$generate$7(Codegen.java:199) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195) [?:?]
	at java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1694) [?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) [?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) [?:?]
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) [?:?]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) [?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) [?:?]
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497) [?:?]
	at aws.cfn.codegen.json.Codegen.generate(Codegen.java:209) [aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Main.execute(Main.java:81) [aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Main.main(Main.java:89) [aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
Exception in thread "main" java.lang.RuntimeException: aws.cfn.codegen.CfnSpecificationException: ParameterValues referenced but not defined in AWS::SSM::Association
	at aws.cfn.codegen.json.Codegen.lambda$generate$7(Codegen.java:206)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1694)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
	at aws.cfn.codegen.json.Codegen.generate(Codegen.java:209)
	at aws.cfn.codegen.json.Main.execute(Main.java:81)
	at aws.cfn.codegen.json.Main.main(Main.java:89)
Caused by: aws.cfn.codegen.CfnSpecificationException: ParameterValues referenced but not defined in AWS::SSM::Association
	at aws.cfn.codegen.CfnSpecification.lambda$validate$0(CfnSpecification.java:35)
	at java.base/java.util.Optional.ifPresent(Optional.java:176)
	at aws.cfn.codegen.CfnSpecification.lambda$validate$1(CfnSpecification.java:32)
	at java.base/java.util.LinkedHashMap.forEach(LinkedHashMap.java:723)
	at aws.cfn.codegen.CfnSpecification.lambda$validate$2(CfnSpecification.java:30)
	at java.base/java.util.LinkedHashMap.forEach(LinkedHashMap.java:723)
	at aws.cfn.codegen.CfnSpecification.validate(CfnSpecification.java:28)
	at aws.cfn.codegen.json.Codegen.loadSpecification(Codegen.java:66)
	at aws.cfn.codegen.json.Codegen.lambda$generate$7(Codegen.java:199)
	... 11 more
```

so I switched
* [`AWS::SSM::Association.Parameters`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-association.html#cfn-ssm-association-parameters) from `"ItemType": "ParameterValues"` to `"PrimitiveType": "String"` 
* [`AWS::IoT::ProvisioningTemplate.Tags`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-provisioningtemplate.html#cfn-iot-provisioningtemplate-tags) from `"ItemType": "Json"` to `"ItemType": "Tag"`

in the [CloudFormation Resource Specification](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html) and used [that](https://gist.githubusercontent.com/PatMyron/b05935a62fac1c136a2b6809e0e1b670/raw/197be2fbe57754b26f46a7687128663b5f913360/CloudFormationResourceSpecification.json) instead:

```shell
aws-cloudformation-template-schema $ git diff
diff --git a/src/main/resources/config.yml b/src/main/resources/config.yml
index f58bb07..217e059 100644
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -33,7 +33,7 @@ settings:
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html
 specifications:
   # US Region
-  us-east-1: https://d1uauaxba7bl26.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json
+  us-east-1: https://gist.githubusercontent.com/PatMyron/b05935a62fac1c136a2b6809e0e1b670/raw/197be2fbe57754b26f46a7687128663b5f913360/CloudFormationResourceSpecification.json
```
```shell
curl -s --compressed https://d1uauaxba7bl26.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json | gsed 's/"ItemType": "ParameterValues"/"PrimitiveType": "String"/' | pbcopy
open https://gist.github.com/PatMyron/b05935a62fac1c136a2b6809e0e1b670/edit
```