### PR TITLE
CloudFormation Template Schema 16.3.0

### DIFF
--- a/schema/all-spec.json
+++ b/schema/all-spec.json
@@ -1310,16 +1310,16 @@
       "Properties" : {
         "type" : "object",
         "properties" : {
-          "CertificateArn" : {
-            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-domainname.html#cfn-apigateway-domainname-certificatearn",
-            "type" : [ "string", "object" ]
-          },
           "DomainName" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-domainname.html#cfn-apigateway-domainname-domainname",
             "type" : [ "string", "object" ]
           },
           "EndpointConfiguration" : {
             "$ref" : "#/definitions/AWS_ApiGateway_DomainName_EndpointConfiguration"
+          },
+          "CertificateArn" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-domainname.html#cfn-apigateway-domainname-certificatearn",
+            "type" : [ "string", "object" ]
           },
           "RegionalCertificateArn" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-domainname.html#cfn-apigateway-domainname-regionalcertificatearn",
@@ -1338,7 +1338,6 @@
             "minItems" : 0
           }
         },
-        "required" : [ "DomainName" ],
         "additionalProperties" : false
       },
       "DependsOn" : {
@@ -1348,7 +1347,7 @@
         }
       }
     },
-    "required" : [ "Type", "Properties" ],
+    "required" : [ "Type" ],
     "additionalProperties" : false
   },
   "AWS_ApiGateway_GatewayResponse" : {
@@ -3025,6 +3024,59 @@
     "required" : [ "Type", "Properties" ],
     "additionalProperties" : false
   },
+  "AWS_AppMesh_GatewayRoute" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-gatewayroute.html",
+    "properties" : {
+      "Type" : {
+        "description" : "Type of resource equals only AWS::AppMesh::GatewayRoute",
+        "type" : "string",
+        "enum" : [ "AWS::AppMesh::GatewayRoute" ]
+      },
+      "Properties" : {
+        "type" : "object",
+        "properties" : {
+          "MeshName" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-gatewayroute.html#cfn-appmesh-gatewayroute-meshname",
+            "type" : [ "string", "object" ]
+          },
+          "VirtualGatewayName" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-gatewayroute.html#cfn-appmesh-gatewayroute-virtualgatewayname",
+            "type" : [ "string", "object" ]
+          },
+          "MeshOwner" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-gatewayroute.html#cfn-appmesh-gatewayroute-meshowner",
+            "type" : [ "string", "object" ]
+          },
+          "GatewayRouteName" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-gatewayroute.html#cfn-appmesh-gatewayroute-gatewayroutename",
+            "type" : [ "string", "object" ]
+          },
+          "Spec" : {
+            "$ref" : "#/definitions/AWS_AppMesh_GatewayRoute_GatewayRouteSpec"
+          },
+          "Tags" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-gatewayroute.html#cfn-appmesh-gatewayroute-tags",
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/Tag"
+            },
+            "minItems" : 0
+          }
+        },
+        "required" : [ "MeshName", "VirtualGatewayName", "GatewayRouteName" ],
+        "additionalProperties" : false
+      },
+      "DependsOn" : {
+        "type" : [ "string", "array" ],
+        "items" : {
+          "type" : "string"
+        }
+      }
+    },
+    "required" : [ "Type", "Properties" ],
+    "additionalProperties" : false
+  },
   "AWS_AppMesh_Mesh" : {
     "type" : "object",
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-mesh.html",
@@ -3107,6 +3159,55 @@
           }
         },
         "required" : [ "MeshName", "VirtualRouterName", "RouteName" ],
+        "additionalProperties" : false
+      },
+      "DependsOn" : {
+        "type" : [ "string", "array" ],
+        "items" : {
+          "type" : "string"
+        }
+      }
+    },
+    "required" : [ "Type", "Properties" ],
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_VirtualGateway" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-virtualgateway.html",
+    "properties" : {
+      "Type" : {
+        "description" : "Type of resource equals only AWS::AppMesh::VirtualGateway",
+        "type" : "string",
+        "enum" : [ "AWS::AppMesh::VirtualGateway" ]
+      },
+      "Properties" : {
+        "type" : "object",
+        "properties" : {
+          "VirtualGatewayName" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-virtualgateway.html#cfn-appmesh-virtualgateway-virtualgatewayname",
+            "type" : [ "string", "object" ]
+          },
+          "MeshName" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-virtualgateway.html#cfn-appmesh-virtualgateway-meshname",
+            "type" : [ "string", "object" ]
+          },
+          "MeshOwner" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-virtualgateway.html#cfn-appmesh-virtualgateway-meshowner",
+            "type" : [ "string", "object" ]
+          },
+          "Spec" : {
+            "$ref" : "#/definitions/AWS_AppMesh_VirtualGateway_VirtualGatewaySpec"
+          },
+          "Tags" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-virtualgateway.html#cfn-appmesh-virtualgateway-tags",
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/Tag"
+            },
+            "minItems" : 0
+          }
+        },
+        "required" : [ "VirtualGatewayName", "MeshName" ],
         "additionalProperties" : false
       },
       "DependsOn" : {
@@ -6226,6 +6327,9 @@
             },
             "minItems" : 0
           },
+          "BuildBatchConfig" : {
+            "$ref" : "#/definitions/AWS_CodeBuild_Project_ProjectBuildBatchConfig"
+          },
           "Tags" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codebuild-project.html#cfn-codebuild-project-tags",
             "type" : "array",
@@ -6582,6 +6686,23 @@
           "AgentPermissions" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codeguruprofiler-profilinggroup.html#cfn-codeguruprofiler-profilinggroup-agentpermissions",
             "type" : [ "object" ]
+          },
+          "AnomalyDetectionNotificationConfiguration" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codeguruprofiler-profilinggroup.html#cfn-codeguruprofiler-profilinggroup-anomalydetectionnotificationconfiguration",
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/AWS_CodeGuruProfiler_ProfilingGroup_Channel"
+            },
+            "minItems" : 0
+          },
+          "Tags" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codeguruprofiler-profilinggroup.html#cfn-codeguruprofiler-profilinggroup-tags",
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/Tag"
+            },
+            "uniqueItems" : true,
+            "minItems" : 0
           }
         },
         "required" : [ "ProfilingGroupName" ],
@@ -18801,12 +18922,7 @@
             "$ref" : "#/definitions/AWS_IoT_ProvisioningTemplate_ProvisioningHook"
           },
           "Tags" : {
-            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-provisioningtemplate.html#cfn-iot-provisioningtemplate-tags",
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/definitions/Tag"
-            },
-            "minItems" : 0
+            "$ref" : "#/definitions/AWS_IoT_ProvisioningTemplate_Tags"
           }
         },
         "required" : [ "ProvisioningRoleArn", "TemplateBody" ],
@@ -19728,6 +19844,9 @@
           },
           "SplunkDestinationConfiguration" : {
             "$ref" : "#/definitions/AWS_KinesisFirehose_DeliveryStream_SplunkDestinationConfiguration"
+          },
+          "HttpEndpointDestinationConfiguration" : {
+            "$ref" : "#/definitions/AWS_KinesisFirehose_DeliveryStream_HttpEndpointDestinationConfiguration"
           }
         },
         "additionalProperties" : false
@@ -30715,7 +30834,6 @@
         "items" : {
           "type" : [ "string", "object" ]
         },
-        "uniqueItems" : true,
         "minItems" : 0
       }
     },
@@ -31483,6 +31601,113 @@
     },
     "additionalProperties" : false
   },
+  "AWS_AppMesh_GatewayRoute_GatewayRouteSpec" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-gatewayroute-gatewayroutespec.html",
+    "properties" : {
+      "HttpRoute" : {
+        "$ref" : "#/definitions/AWS_AppMesh_GatewayRoute_HttpGatewayRoute"
+      },
+      "Http2Route" : {
+        "$ref" : "#/definitions/AWS_AppMesh_GatewayRoute_HttpGatewayRoute"
+      },
+      "GrpcRoute" : {
+        "$ref" : "#/definitions/AWS_AppMesh_GatewayRoute_GrpcGatewayRoute"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_GatewayRoute_GatewayRouteTarget" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-gatewayroute-gatewayroutetarget.html",
+    "properties" : {
+      "VirtualService" : {
+        "$ref" : "#/definitions/AWS_AppMesh_GatewayRoute_GatewayRouteVirtualService"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_GatewayRoute_GatewayRouteVirtualService" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-gatewayroute-gatewayroutevirtualservice.html",
+    "properties" : {
+      "VirtualServiceName" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-gatewayroute-gatewayroutevirtualservice.html#cfn-appmesh-gatewayroute-gatewayroutevirtualservice-virtualservicename",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "required" : [ "VirtualServiceName" ],
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_GatewayRoute_GrpcGatewayRoute" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-gatewayroute-grpcgatewayroute.html",
+    "properties" : {
+      "Action" : {
+        "$ref" : "#/definitions/AWS_AppMesh_GatewayRoute_GrpcGatewayRouteAction"
+      },
+      "Match" : {
+        "$ref" : "#/definitions/AWS_AppMesh_GatewayRoute_GrpcGatewayRouteMatch"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_GatewayRoute_GrpcGatewayRouteAction" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-gatewayroute-grpcgatewayrouteaction.html",
+    "properties" : {
+      "Target" : {
+        "$ref" : "#/definitions/AWS_AppMesh_GatewayRoute_GatewayRouteTarget"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_GatewayRoute_GrpcGatewayRouteMatch" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-gatewayroute-grpcgatewayroutematch.html",
+    "properties" : {
+      "ServiceName" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-gatewayroute-grpcgatewayroutematch.html#cfn-appmesh-gatewayroute-grpcgatewayroutematch-servicename",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_GatewayRoute_HttpGatewayRoute" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-gatewayroute-httpgatewayroute.html",
+    "properties" : {
+      "Action" : {
+        "$ref" : "#/definitions/AWS_AppMesh_GatewayRoute_HttpGatewayRouteAction"
+      },
+      "Match" : {
+        "$ref" : "#/definitions/AWS_AppMesh_GatewayRoute_HttpGatewayRouteMatch"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_GatewayRoute_HttpGatewayRouteAction" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-gatewayroute-httpgatewayrouteaction.html",
+    "properties" : {
+      "Target" : {
+        "$ref" : "#/definitions/AWS_AppMesh_GatewayRoute_GatewayRouteTarget"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_GatewayRoute_HttpGatewayRouteMatch" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-gatewayroute-httpgatewayroutematch.html",
+    "properties" : {
+      "Prefix" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-gatewayroute-httpgatewayroutematch.html#cfn-appmesh-gatewayroute-httpgatewayroutematch-prefix",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "required" : [ "Prefix" ],
+    "additionalProperties" : false
+  },
   "AWS_AppMesh_Mesh_EgressFilter" : {
     "type" : "object",
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-mesh-egressfilter.html",
@@ -31920,6 +32145,277 @@
       }
     },
     "required" : [ "VirtualNode", "Weight" ],
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_VirtualGateway_VirtualGatewayAccessLog" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayaccesslog.html",
+    "properties" : {
+      "File" : {
+        "$ref" : "#/definitions/AWS_AppMesh_VirtualGateway_VirtualGatewayFileAccessLog"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_VirtualGateway_VirtualGatewayBackendDefaults" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewaybackenddefaults.html",
+    "properties" : {
+      "ClientPolicy" : {
+        "$ref" : "#/definitions/AWS_AppMesh_VirtualGateway_VirtualGatewayClientPolicy"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_VirtualGateway_VirtualGatewayClientPolicy" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayclientpolicy.html",
+    "properties" : {
+      "TLS" : {
+        "$ref" : "#/definitions/AWS_AppMesh_VirtualGateway_VirtualGatewayClientPolicyTls"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_VirtualGateway_VirtualGatewayClientPolicyTls" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayclientpolicytls.html",
+    "properties" : {
+      "Validation" : {
+        "$ref" : "#/definitions/AWS_AppMesh_VirtualGateway_VirtualGatewayTlsValidationContext"
+      },
+      "Enforce" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayclientpolicytls.html#cfn-appmesh-virtualgateway-virtualgatewayclientpolicytls-enforce",
+        "type" : [ "boolean", "object" ]
+      },
+      "Ports" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayclientpolicytls.html#cfn-appmesh-virtualgateway-virtualgatewayclientpolicytls-ports",
+        "type" : "array",
+        "items" : {
+          "type" : [ "integer", "object" ]
+        },
+        "minItems" : 0
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_VirtualGateway_VirtualGatewayFileAccessLog" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayfileaccesslog.html",
+    "properties" : {
+      "Path" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayfileaccesslog.html#cfn-appmesh-virtualgateway-virtualgatewayfileaccesslog-path",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "required" : [ "Path" ],
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_VirtualGateway_VirtualGatewayHealthCheckPolicy" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayhealthcheckpolicy.html",
+    "properties" : {
+      "Path" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayhealthcheckpolicy.html#cfn-appmesh-virtualgateway-virtualgatewayhealthcheckpolicy-path",
+        "type" : [ "string", "object" ]
+      },
+      "UnhealthyThreshold" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayhealthcheckpolicy.html#cfn-appmesh-virtualgateway-virtualgatewayhealthcheckpolicy-unhealthythreshold",
+        "type" : [ "integer", "object" ]
+      },
+      "Port" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayhealthcheckpolicy.html#cfn-appmesh-virtualgateway-virtualgatewayhealthcheckpolicy-port",
+        "type" : [ "integer", "object" ]
+      },
+      "HealthyThreshold" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayhealthcheckpolicy.html#cfn-appmesh-virtualgateway-virtualgatewayhealthcheckpolicy-healthythreshold",
+        "type" : [ "integer", "object" ]
+      },
+      "TimeoutMillis" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayhealthcheckpolicy.html#cfn-appmesh-virtualgateway-virtualgatewayhealthcheckpolicy-timeoutmillis",
+        "type" : [ "integer", "object" ]
+      },
+      "Protocol" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayhealthcheckpolicy.html#cfn-appmesh-virtualgateway-virtualgatewayhealthcheckpolicy-protocol",
+        "type" : [ "string", "object" ]
+      },
+      "IntervalMillis" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayhealthcheckpolicy.html#cfn-appmesh-virtualgateway-virtualgatewayhealthcheckpolicy-intervalmillis",
+        "type" : [ "integer", "object" ]
+      }
+    },
+    "required" : [ "UnhealthyThreshold", "HealthyThreshold", "TimeoutMillis", "Protocol", "IntervalMillis" ],
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_VirtualGateway_VirtualGatewayListener" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewaylistener.html",
+    "properties" : {
+      "HealthCheck" : {
+        "$ref" : "#/definitions/AWS_AppMesh_VirtualGateway_VirtualGatewayHealthCheckPolicy"
+      },
+      "TLS" : {
+        "$ref" : "#/definitions/AWS_AppMesh_VirtualGateway_VirtualGatewayListenerTls"
+      },
+      "PortMapping" : {
+        "$ref" : "#/definitions/AWS_AppMesh_VirtualGateway_VirtualGatewayPortMapping"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_VirtualGateway_VirtualGatewayListenerTls" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewaylistenertls.html",
+    "properties" : {
+      "Mode" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewaylistenertls.html#cfn-appmesh-virtualgateway-virtualgatewaylistenertls-mode",
+        "type" : [ "string", "object" ]
+      },
+      "Certificate" : {
+        "$ref" : "#/definitions/AWS_AppMesh_VirtualGateway_VirtualGatewayListenerTlsCertificate"
+      }
+    },
+    "required" : [ "Mode" ],
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_VirtualGateway_VirtualGatewayListenerTlsAcmCertificate" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewaylistenertlsacmcertificate.html",
+    "properties" : {
+      "CertificateArn" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewaylistenertlsacmcertificate.html#cfn-appmesh-virtualgateway-virtualgatewaylistenertlsacmcertificate-certificatearn",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "required" : [ "CertificateArn" ],
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_VirtualGateway_VirtualGatewayListenerTlsCertificate" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewaylistenertlscertificate.html",
+    "properties" : {
+      "ACM" : {
+        "$ref" : "#/definitions/AWS_AppMesh_VirtualGateway_VirtualGatewayListenerTlsAcmCertificate"
+      },
+      "File" : {
+        "$ref" : "#/definitions/AWS_AppMesh_VirtualGateway_VirtualGatewayListenerTlsFileCertificate"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_VirtualGateway_VirtualGatewayListenerTlsFileCertificate" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewaylistenertlsfilecertificate.html",
+    "properties" : {
+      "PrivateKey" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewaylistenertlsfilecertificate.html#cfn-appmesh-virtualgateway-virtualgatewaylistenertlsfilecertificate-privatekey",
+        "type" : [ "string", "object" ]
+      },
+      "CertificateChain" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewaylistenertlsfilecertificate.html#cfn-appmesh-virtualgateway-virtualgatewaylistenertlsfilecertificate-certificatechain",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "required" : [ "PrivateKey", "CertificateChain" ],
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_VirtualGateway_VirtualGatewayLogging" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewaylogging.html",
+    "properties" : {
+      "AccessLog" : {
+        "$ref" : "#/definitions/AWS_AppMesh_VirtualGateway_VirtualGatewayAccessLog"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_VirtualGateway_VirtualGatewayPortMapping" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayportmapping.html",
+    "properties" : {
+      "Port" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayportmapping.html#cfn-appmesh-virtualgateway-virtualgatewayportmapping-port",
+        "type" : [ "integer", "object" ]
+      },
+      "Protocol" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayportmapping.html#cfn-appmesh-virtualgateway-virtualgatewayportmapping-protocol",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "required" : [ "Port", "Protocol" ],
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_VirtualGateway_VirtualGatewaySpec" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayspec.html",
+    "properties" : {
+      "Logging" : {
+        "$ref" : "#/definitions/AWS_AppMesh_VirtualGateway_VirtualGatewayLogging"
+      },
+      "Listeners" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewayspec.html#cfn-appmesh-virtualgateway-virtualgatewayspec-listeners",
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/definitions/AWS_AppMesh_VirtualGateway_VirtualGatewayListener"
+        },
+        "minItems" : 0
+      },
+      "BackendDefaults" : {
+        "$ref" : "#/definitions/AWS_AppMesh_VirtualGateway_VirtualGatewayBackendDefaults"
+      }
+    },
+    "required" : [ "Listeners" ],
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_VirtualGateway_VirtualGatewayTlsValidationContext" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewaytlsvalidationcontext.html",
+    "properties" : {
+      "Trust" : {
+        "$ref" : "#/definitions/AWS_AppMesh_VirtualGateway_VirtualGatewayTlsValidationContextTrust"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_VirtualGateway_VirtualGatewayTlsValidationContextAcmTrust" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewaytlsvalidationcontextacmtrust.html",
+    "properties" : {
+      "CertificateAuthorityArns" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewaytlsvalidationcontextacmtrust.html#cfn-appmesh-virtualgateway-virtualgatewaytlsvalidationcontextacmtrust-certificateauthorityarns",
+        "type" : "array",
+        "items" : {
+          "type" : [ "string", "object" ]
+        },
+        "minItems" : 0
+      }
+    },
+    "required" : [ "CertificateAuthorityArns" ],
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_VirtualGateway_VirtualGatewayTlsValidationContextFileTrust" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewaytlsvalidationcontextfiletrust.html",
+    "properties" : {
+      "CertificateChain" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewaytlsvalidationcontextfiletrust.html#cfn-appmesh-virtualgateway-virtualgatewaytlsvalidationcontextfiletrust-certificatechain",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "required" : [ "CertificateChain" ],
+    "additionalProperties" : false
+  },
+  "AWS_AppMesh_VirtualGateway_VirtualGatewayTlsValidationContextTrust" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualgateway-virtualgatewaytlsvalidationcontexttrust.html",
+    "properties" : {
+      "ACM" : {
+        "$ref" : "#/definitions/AWS_AppMesh_VirtualGateway_VirtualGatewayTlsValidationContextAcmTrust"
+      },
+      "File" : {
+        "$ref" : "#/definitions/AWS_AppMesh_VirtualGateway_VirtualGatewayTlsValidationContextFileTrust"
+      }
+    },
     "additionalProperties" : false
   },
   "AWS_AppMesh_VirtualNode_AccessLog" : {
@@ -35756,6 +36252,25 @@
     "required" : [ "Type" ],
     "additionalProperties" : false
   },
+  "AWS_CodeBuild_Project_BatchRestrictions" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-batchrestrictions.html",
+    "properties" : {
+      "ComputeTypesAllowed" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-batchrestrictions.html#cfn-codebuild-project-batchrestrictions-computetypesallowed",
+        "type" : "array",
+        "items" : {
+          "type" : [ "string", "object" ]
+        },
+        "minItems" : 0
+      },
+      "MaximumBuildsAllowed" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-batchrestrictions.html#cfn-codebuild-project-batchrestrictions-maximumbuildsallowed",
+        "type" : [ "integer", "object" ]
+      }
+    },
+    "additionalProperties" : false
+  },
   "AWS_CodeBuild_Project_BuildStatusConfig" : {
     "type" : "object",
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-buildstatusconfig.html",
@@ -35881,6 +36396,28 @@
       },
       "S3Logs" : {
         "$ref" : "#/definitions/AWS_CodeBuild_Project_S3LogsConfig"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_CodeBuild_Project_ProjectBuildBatchConfig" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-projectbuildbatchconfig.html",
+    "properties" : {
+      "CombineArtifacts" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-projectbuildbatchconfig.html#cfn-codebuild-project-projectbuildbatchconfig-combineartifacts",
+        "type" : [ "boolean", "object" ]
+      },
+      "ServiceRole" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-projectbuildbatchconfig.html#cfn-codebuild-project-projectbuildbatchconfig-servicerole",
+        "type" : [ "string", "object" ]
+      },
+      "TimeoutInMins" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-projectbuildbatchconfig.html#cfn-codebuild-project-projectbuildbatchconfig-timeoutinmins",
+        "type" : [ "integer", "object" ]
+      },
+      "Restrictions" : {
+        "$ref" : "#/definitions/AWS_CodeBuild_Project_BatchRestrictions"
       }
     },
     "additionalProperties" : false
@@ -36561,6 +37098,22 @@
         "type" : [ "string", "object" ]
       }
     },
+    "additionalProperties" : false
+  },
+  "AWS_CodeGuruProfiler_ProfilingGroup_Channel" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codeguruprofiler-profilinggroup-channel.html",
+    "properties" : {
+      "channelId" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codeguruprofiler-profilinggroup-channel.html#cfn-codeguruprofiler-profilinggroup-channel-channelid",
+        "type" : [ "string", "object" ]
+      },
+      "channelUri" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codeguruprofiler-profilinggroup-channel.html#cfn-codeguruprofiler-profilinggroup-channel-channeluri",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "required" : [ "channelUri" ],
     "additionalProperties" : false
   },
   "AWS_CodePipeline_CustomActionType_ArtifactDetails" : {
@@ -44707,6 +45260,10 @@
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fsx-filesystem-lustreconfiguration.html#cfn-fsx-filesystem-lustreconfiguration-weeklymaintenancestarttime",
         "type" : [ "string", "object" ]
       },
+      "AutoImportPolicy" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fsx-filesystem-lustreconfiguration.html#cfn-fsx-filesystem-lustreconfiguration-autoimportpolicy",
+        "type" : [ "string", "object" ]
+      },
       "ImportedFileChunkSize" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fsx-filesystem-lustreconfiguration.html#cfn-fsx-filesystem-lustreconfiguration-importedfilechunksize",
         "type" : [ "integer", "object" ]
@@ -47375,6 +47932,21 @@
       "PayloadVersion" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iot-provisioningtemplate-provisioninghook.html#cfn-iot-provisioningtemplate-provisioninghook-payloadversion",
         "type" : [ "string", "object" ]
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_IoT_ProvisioningTemplate_Tags" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iot-provisioningtemplate-tags.html",
+    "properties" : {
+      "Tags" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iot-provisioningtemplate-tags.html#cfn-iot-provisioningtemplate-tags-tags",
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/definitions/AWS_IoT_ProvisioningTemplate_Json"
+        },
+        "minItems" : 0
       }
     },
     "additionalProperties" : false
@@ -50504,6 +51076,98 @@
     },
     "additionalProperties" : false
   },
+  "AWS_KinesisFirehose_DeliveryStream_HttpEndpointCommonAttribute" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-httpendpointcommonattribute.html",
+    "properties" : {
+      "AttributeName" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-httpendpointcommonattribute.html#cfn-kinesisfirehose-deliverystream-httpendpointcommonattribute-attributename",
+        "type" : [ "string", "object" ]
+      },
+      "AttributeValue" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-httpendpointcommonattribute.html#cfn-kinesisfirehose-deliverystream-httpendpointcommonattribute-attributevalue",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "required" : [ "AttributeName", "AttributeValue" ],
+    "additionalProperties" : false
+  },
+  "AWS_KinesisFirehose_DeliveryStream_HttpEndpointConfiguration" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-httpendpointconfiguration.html",
+    "properties" : {
+      "Url" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-httpendpointconfiguration.html#cfn-kinesisfirehose-deliverystream-httpendpointconfiguration-url",
+        "type" : [ "string", "object" ]
+      },
+      "AccessKey" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-httpendpointconfiguration.html#cfn-kinesisfirehose-deliverystream-httpendpointconfiguration-accesskey",
+        "type" : [ "string", "object" ]
+      },
+      "Name" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-httpendpointconfiguration.html#cfn-kinesisfirehose-deliverystream-httpendpointconfiguration-name",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "required" : [ "Url" ],
+    "additionalProperties" : false
+  },
+  "AWS_KinesisFirehose_DeliveryStream_HttpEndpointDestinationConfiguration" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-httpendpointdestinationconfiguration.html",
+    "properties" : {
+      "RoleARN" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-httpendpointdestinationconfiguration.html#cfn-kinesisfirehose-deliverystream-httpendpointdestinationconfiguration-rolearn",
+        "type" : [ "string", "object" ]
+      },
+      "EndpointConfiguration" : {
+        "$ref" : "#/definitions/AWS_KinesisFirehose_DeliveryStream_HttpEndpointConfiguration"
+      },
+      "RequestConfiguration" : {
+        "$ref" : "#/definitions/AWS_KinesisFirehose_DeliveryStream_HttpEndpointRequestConfiguration"
+      },
+      "BufferingHints" : {
+        "$ref" : "#/definitions/AWS_KinesisFirehose_DeliveryStream_BufferingHints"
+      },
+      "CloudWatchLoggingOptions" : {
+        "$ref" : "#/definitions/AWS_KinesisFirehose_DeliveryStream_CloudWatchLoggingOptions"
+      },
+      "ProcessingConfiguration" : {
+        "$ref" : "#/definitions/AWS_KinesisFirehose_DeliveryStream_ProcessingConfiguration"
+      },
+      "RetryOptions" : {
+        "$ref" : "#/definitions/AWS_KinesisFirehose_DeliveryStream_RetryOptions"
+      },
+      "S3BackupMode" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-httpendpointdestinationconfiguration.html#cfn-kinesisfirehose-deliverystream-httpendpointdestinationconfiguration-s3backupmode",
+        "type" : [ "string", "object" ]
+      },
+      "S3Configuration" : {
+        "$ref" : "#/definitions/AWS_KinesisFirehose_DeliveryStream_S3DestinationConfiguration"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_KinesisFirehose_DeliveryStream_HttpEndpointRequestConfiguration" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-httpendpointrequestconfiguration.html",
+    "properties" : {
+      "ContentEncoding" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-httpendpointrequestconfiguration.html#cfn-kinesisfirehose-deliverystream-httpendpointrequestconfiguration-contentencoding",
+        "type" : [ "string", "object" ]
+      },
+      "CommonAttributes" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-httpendpointrequestconfiguration.html#cfn-kinesisfirehose-deliverystream-httpendpointrequestconfiguration-commonattributes",
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/definitions/AWS_KinesisFirehose_DeliveryStream_HttpEndpointCommonAttribute"
+        },
+        "uniqueItems" : true,
+        "minItems" : 0
+      }
+    },
+    "additionalProperties" : false
+  },
   "AWS_KinesisFirehose_DeliveryStream_InputFormatConfiguration" : {
     "type" : "object",
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-inputformatconfiguration.html",
@@ -50768,6 +51432,17 @@
     "properties" : {
       "DurationInSeconds" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-redshiftretryoptions.html#cfn-kinesisfirehose-deliverystream-redshiftretryoptions-durationinseconds",
+        "type" : [ "integer", "object" ]
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_KinesisFirehose_DeliveryStream_RetryOptions" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-retryoptions.html",
+    "properties" : {
+      "DurationInSeconds" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-retryoptions.html#cfn-kinesisfirehose-deliverystream-retryoptions-durationinseconds",
         "type" : [ "integer", "object" ]
       }
     },
@@ -58946,9 +59621,13 @@
         }, {
           "$ref" : "#/definitions/AWS_AppConfig_HostedConfigurationVersion"
         }, {
+          "$ref" : "#/definitions/AWS_AppMesh_GatewayRoute"
+        }, {
           "$ref" : "#/definitions/AWS_AppMesh_Mesh"
         }, {
           "$ref" : "#/definitions/AWS_AppMesh_Route"
+        }, {
+          "$ref" : "#/definitions/AWS_AppMesh_VirtualGateway"
         }, {
           "$ref" : "#/definitions/AWS_AppMesh_VirtualNode"
         }, {
@@ -59995,7 +60674,7 @@
       "$ref": "#/definitions/resources"
     }
   },
-  "description": "CFN JSON specification generated from version 16.2.0",
+  "description": "CFN JSON specification generated from version 16.3.0",
   "required": [
     "Resources"
   ]


### PR DESCRIPTION
https://github.com/aws-cloudformation/aws-cloudformation-template-schema/issues/32

https://github.com/aws-cloudformation/aws-cloudformation-template-schema/blob/master/docs/tool/instructions.md

as described in https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code/pull/76

---

[reverted this Dependabot upgrade locally](https://github.com/aws-cloudformation/aws-cloudformation-template-schema/pull/44#issuecomment-652625502)

[still running into:](https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code/pull/85)

```java
aws.cfn.codegen.CfnSpecificationException: ParameterValues referenced but not defined in AWS::SSM::Association
	at aws.cfn.codegen.CfnSpecification.lambda$validate$0(CfnSpecification.java:35) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.Optional.ifPresent(Optional.java:176) ~[?:?]
	at aws.cfn.codegen.CfnSpecification.lambda$validate$1(CfnSpecification.java:32) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.LinkedHashMap.forEach(LinkedHashMap.java:723) ~[?:?]
	at aws.cfn.codegen.CfnSpecification.lambda$validate$2(CfnSpecification.java:30) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.LinkedHashMap.forEach(LinkedHashMap.java:723) ~[?:?]
	at aws.cfn.codegen.CfnSpecification.validate(CfnSpecification.java:28) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Codegen.loadSpecification(Codegen.java:66) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Codegen.lambda$generate$7(Codegen.java:199) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195) [?:?]
	at java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1694) [?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) [?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) [?:?]
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) [?:?]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) [?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) [?:?]
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497) [?:?]
	at aws.cfn.codegen.json.Codegen.generate(Codegen.java:209) [aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Main.execute(Main.java:81) [aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Main.main(Main.java:89) [aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
Exception in thread "main" java.lang.RuntimeException: aws.cfn.codegen.CfnSpecificationException: ParameterValues referenced but not defined in AWS::SSM::Association
	at aws.cfn.codegen.json.Codegen.lambda$generate$7(Codegen.java:206)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1694)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
	at aws.cfn.codegen.json.Codegen.generate(Codegen.java:209)
	at aws.cfn.codegen.json.Main.execute(Main.java:81)
	at aws.cfn.codegen.json.Main.main(Main.java:89)
Caused by: aws.cfn.codegen.CfnSpecificationException: ParameterValues referenced but not defined in AWS::SSM::Association
	at aws.cfn.codegen.CfnSpecification.lambda$validate$0(CfnSpecification.java:35)
	at java.base/java.util.Optional.ifPresent(Optional.java:176)
	at aws.cfn.codegen.CfnSpecification.lambda$validate$1(CfnSpecification.java:32)
	at java.base/java.util.LinkedHashMap.forEach(LinkedHashMap.java:723)
	at aws.cfn.codegen.CfnSpecification.lambda$validate$2(CfnSpecification.java:30)
	at java.base/java.util.LinkedHashMap.forEach(LinkedHashMap.java:723)
	at aws.cfn.codegen.CfnSpecification.validate(CfnSpecification.java:28)
	at aws.cfn.codegen.json.Codegen.loadSpecification(Codegen.java:66)
	at aws.cfn.codegen.json.Codegen.lambda$generate$7(Codegen.java:199)
	... 11 more
```

so I switched
* [`AWS::SSM::Association.Parameters`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-association.html#cfn-ssm-association-parameters) from `"ItemType": "ParameterValues"` to `"PrimitiveType": "String"` 

in the [CloudFormation Resource Specification](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html) and used [that](https://gist.githubusercontent.com/PatMyron/b05935a62fac1c136a2b6809e0e1b670/raw/6d4603d9345998685ab79f1b683afb611b7ec6b5/CloudFormationResourceSpecification.json) instead:

```shell
aws-cloudformation-template-schema $ git diff
diff --git a/src/main/resources/config.yml b/src/main/resources/config.yml
index f58bb07..217e059 100644
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -33,7 +33,7 @@ settings:
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html
 specifications:
   # US Region
-  us-east-1: https://d1uauaxba7bl26.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json
+  us-east-1: https://gist.githubusercontent.com/PatMyron/b05935a62fac1c136a2b6809e0e1b670/raw/6d4603d9345998685ab79f1b683afb611b7ec6b5/CloudFormationResourceSpecification.json
```
```shell
curl -s --compressed https://d1uauaxba7bl26.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json | gsed 's/"ItemType": "ParameterValues"/"PrimitiveType": "String"/' | pbcopy
open https://gist.github.com/PatMyron/b05935a62fac1c136a2b6809e0e1b670/edit
```