### PR TITLE
CloudFormation Template Schema 18.1.0

### DIFF
--- a/schema/all-spec.json
+++ b/schema/all-spec.json
@@ -17545,6 +17545,9 @@
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html#cfn-guardduty-detector-findingpublishingfrequency",
             "type" : [ "string", "object" ]
           },
+          "DataSources" : {
+            "$ref" : "#/definitions/AWS_GuardDuty_Detector_CFNDataSourceConfigurations"
+          },
           "Enable" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html#cfn-guardduty-detector-enable",
             "type" : [ "boolean", "object" ]
@@ -25914,6 +25917,72 @@
     "required" : [ "Type", "Properties" ],
     "additionalProperties" : false
   },
+  "AWS_Route53Resolver_ResolverQueryLoggingConfig" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverqueryloggingconfig.html",
+    "properties" : {
+      "Type" : {
+        "description" : "Type of resource equals only AWS::Route53Resolver::ResolverQueryLoggingConfig",
+        "type" : "string",
+        "enum" : [ "AWS::Route53Resolver::ResolverQueryLoggingConfig" ]
+      },
+      "Properties" : {
+        "type" : "object",
+        "properties" : {
+          "Name" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverqueryloggingconfig.html#cfn-route53resolver-resolverqueryloggingconfig-name",
+            "type" : [ "string", "object" ]
+          },
+          "DestinationArn" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverqueryloggingconfig.html#cfn-route53resolver-resolverqueryloggingconfig-destinationarn",
+            "type" : [ "string", "object" ]
+          }
+        },
+        "additionalProperties" : false
+      },
+      "DependsOn" : {
+        "type" : [ "string", "array" ],
+        "items" : {
+          "type" : "string"
+        }
+      }
+    },
+    "required" : [ "Type" ],
+    "additionalProperties" : false
+  },
+  "AWS_Route53Resolver_ResolverQueryLoggingConfigAssociation" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverqueryloggingconfigassociation.html",
+    "properties" : {
+      "Type" : {
+        "description" : "Type of resource equals only AWS::Route53Resolver::ResolverQueryLoggingConfigAssociation",
+        "type" : "string",
+        "enum" : [ "AWS::Route53Resolver::ResolverQueryLoggingConfigAssociation" ]
+      },
+      "Properties" : {
+        "type" : "object",
+        "properties" : {
+          "ResolverQueryLogConfigId" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverqueryloggingconfigassociation.html#cfn-route53resolver-resolverqueryloggingconfigassociation-resolverquerylogconfigid",
+            "type" : [ "string", "object" ]
+          },
+          "ResourceId" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverqueryloggingconfigassociation.html#cfn-route53resolver-resolverqueryloggingconfigassociation-resourceid",
+            "type" : [ "string", "object" ]
+          }
+        },
+        "additionalProperties" : false
+      },
+      "DependsOn" : {
+        "type" : [ "string", "array" ],
+        "items" : {
+          "type" : "string"
+        }
+      }
+    },
+    "required" : [ "Type" ],
+    "additionalProperties" : false
+  },
   "AWS_Route53Resolver_ResolverRule" : {
     "type" : "object",
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverrule.html",
@@ -28041,6 +28110,10 @@
           },
           "PathId" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-cloudformationprovisionedproduct.html#cfn-servicecatalog-cloudformationprovisionedproduct-pathid",
+            "type" : [ "string", "object" ]
+          },
+          "PathName" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-cloudformationprovisionedproduct.html#cfn-servicecatalog-cloudformationprovisionedproduct-pathname",
             "type" : [ "string", "object" ]
           },
           "ProductId" : {
@@ -35823,6 +35896,10 @@
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-cachebehavior.html#cfn-cloudfront-distribution-cachebehavior-viewerprotocolpolicy",
         "type" : [ "string", "object" ]
       },
+      "RealtimeLogConfigArn" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-cachebehavior.html#cfn-cloudfront-distribution-cachebehavior-realtimelogconfigarn",
+        "type" : [ "string", "object" ]
+      },
       "TrustedSigners" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-cachebehavior.html#cfn-cloudfront-distribution-cachebehavior-trustedsigners",
         "type" : "array",
@@ -35988,6 +36065,10 @@
       },
       "ViewerProtocolPolicy" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-defaultcachebehavior.html#cfn-cloudfront-distribution-defaultcachebehavior-viewerprotocolpolicy",
+        "type" : [ "string", "object" ]
+      },
+      "RealtimeLogConfigArn" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-defaultcachebehavior.html#cfn-cloudfront-distribution-defaultcachebehavior-realtimelogconfigarn",
         "type" : [ "string", "object" ]
       },
       "TrustedSigners" : {
@@ -45987,12 +46068,12 @@
     "type" : "object",
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-gamelift-alias-routingstrategy.html",
     "properties" : {
-      "FleetId" : {
-        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-gamelift-alias-routingstrategy.html#cfn-gamelift-alias-routingstrategy-fleetid",
-        "type" : [ "string", "object" ]
-      },
       "Message" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-gamelift-alias-routingstrategy.html#cfn-gamelift-alias-routingstrategy-message",
+        "type" : [ "string", "object" ]
+      },
+      "FleetId" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-gamelift-alias-routingstrategy.html#cfn-gamelift-alias-routingstrategy-fleetid",
         "type" : [ "string", "object" ]
       },
       "Type" : {
@@ -46000,7 +46081,6 @@
         "type" : [ "string", "object" ]
       }
     },
-    "required" : [ "Type" ],
     "additionalProperties" : false
   },
   "AWS_GameLift_Build_S3Location" : {
@@ -48225,6 +48305,27 @@
       }
     },
     "required" : [ "Target", "Id", "Source", "Subject" ],
+    "additionalProperties" : false
+  },
+  "AWS_GuardDuty_Detector_CFNDataSourceConfigurations" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-guardduty-detector-cfndatasourceconfigurations.html",
+    "properties" : {
+      "S3Logs" : {
+        "$ref" : "#/definitions/AWS_GuardDuty_Detector_CFNS3LogsConfiguration"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_GuardDuty_Detector_CFNS3LogsConfiguration" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-guardduty-detector-cfns3logsconfiguration.html",
+    "properties" : {
+      "Enable" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-guardduty-detector-cfns3logsconfiguration.html#cfn-guardduty-detector-cfns3logsconfiguration-enable",
+        "type" : [ "boolean", "object" ]
+      }
+    },
     "additionalProperties" : false
   },
   "AWS_GuardDuty_Filter_Condition" : {
@@ -61426,6 +61527,10 @@
         }, {
           "$ref" : "#/definitions/AWS_Route53Resolver_ResolverEndpoint"
         }, {
+          "$ref" : "#/definitions/AWS_Route53Resolver_ResolverQueryLoggingConfig"
+        }, {
+          "$ref" : "#/definitions/AWS_Route53Resolver_ResolverQueryLoggingConfigAssociation"
+        }, {
           "$ref" : "#/definitions/AWS_Route53Resolver_ResolverRule"
         }, {
           "$ref" : "#/definitions/AWS_Route53Resolver_ResolverRuleAssociation"
@@ -61653,7 +61758,7 @@
       "$ref": "#/definitions/resources"
     }
   },
-  "description": "CFN JSON specification generated from version 18.0.0",
+  "description": "CFN JSON specification generated from version 18.1.0",
   "required": [
     "Resources"
   ]


### PR DESCRIPTION
https://github.com/aws-cloudformation/aws-cloudformation-template-schema/issues/32

https://github.com/aws-cloudformation/aws-cloudformation-template-schema/blob/master/docs/tool/instructions.md

as described in https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code/pull/76

---

[still running into:](https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code/pull/85)

```java
aws.cfn.codegen.CfnSpecificationException: ParameterValues referenced but not defined in AWS::SSM::Association
	at aws.cfn.codegen.CfnSpecification.lambda$validate$0(CfnSpecification.java:35) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.Optional.ifPresent(Optional.java:176) ~[?:?]
	at aws.cfn.codegen.CfnSpecification.lambda$validate$1(CfnSpecification.java:32) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.LinkedHashMap.forEach(LinkedHashMap.java:723) ~[?:?]
	at aws.cfn.codegen.CfnSpecification.lambda$validate$2(CfnSpecification.java:30) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.LinkedHashMap.forEach(LinkedHashMap.java:723) ~[?:?]
	at aws.cfn.codegen.CfnSpecification.validate(CfnSpecification.java:28) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Codegen.loadSpecification(Codegen.java:66) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Codegen.lambda$generate$7(Codegen.java:199) ~[aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195) [?:?]
	at java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1694) [?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) [?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) [?:?]
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) [?:?]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) [?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) [?:?]
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497) [?:?]
	at aws.cfn.codegen.json.Codegen.generate(Codegen.java:209) [aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Main.execute(Main.java:81) [aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at aws.cfn.codegen.json.Main.main(Main.java:89) [aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
Exception in thread "main" java.lang.RuntimeException: aws.cfn.codegen.CfnSpecificationException: ParameterValues referenced but not defined in AWS::SSM::Association
	at aws.cfn.codegen.json.Codegen.lambda$generate$7(Codegen.java:206)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1694)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
	at aws.cfn.codegen.json.Codegen.generate(Codegen.java:209)
	at aws.cfn.codegen.json.Main.execute(Main.java:81)
	at aws.cfn.codegen.json.Main.main(Main.java:89)
Caused by: aws.cfn.codegen.CfnSpecificationException: ParameterValues referenced but not defined in AWS::SSM::Association
	at aws.cfn.codegen.CfnSpecification.lambda$validate$0(CfnSpecification.java:35)
	at java.base/java.util.Optional.ifPresent(Optional.java:176)
	at aws.cfn.codegen.CfnSpecification.lambda$validate$1(CfnSpecification.java:32)
	at java.base/java.util.LinkedHashMap.forEach(LinkedHashMap.java:723)
	at aws.cfn.codegen.CfnSpecification.lambda$validate$2(CfnSpecification.java:30)
	at java.base/java.util.LinkedHashMap.forEach(LinkedHashMap.java:723)
	at aws.cfn.codegen.CfnSpecification.validate(CfnSpecification.java:28)
	at aws.cfn.codegen.json.Codegen.loadSpecification(Codegen.java:66)
	at aws.cfn.codegen.json.Codegen.lambda$generate$7(Codegen.java:199)
	... 11 more
```

so I switched
* [`AWS::SSM::Association.Parameters`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-association.html#cfn-ssm-association-parameters) from `"ItemType": "ParameterValues"` to `"PrimitiveType": "String"` 

in the [CloudFormation Resource Specification](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html) and used that instead:

```shell
aws-cloudformation-template-schema $ git diff
diff --git a/src/main/resources/config.yml b/src/main/resources/config.yml
index f58bb07..217e059 100644
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -33,7 +33,7 @@ settings:
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html
 specifications:
   # US Region
-  us-east-1: https://d1uauaxba7bl26.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json
+  us-east-1: file:///Users/$USER/Documents/GitHub/aws-cloudformation-template-schema/CloudFormationResourceSpecification.json
```
```shell
curl -s --compressed https://d1uauaxba7bl26.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json | gsed 's/"ItemType": "ParameterValues"/"PrimitiveType": "String"/' > CloudFormationResourceSpecification.json
```