### PR TITLE
CloudFormation Template Schema 18.5.0 + additional Template Schema improvements

### DIFF
--- a/schema/all-spec.json
+++ b/schema/all-spec.json
@@ -32,6 +32,9 @@
           "$comment": "Use a transform to simplify template authoring for serverless applications. ",
           "type": "string",
           "enum": [
+            "AWS::CodeDeployBlueGreen",
+            "AWS::CodeStar",
+            "AWS::SecretsManager-2020-07-23",
             "AWS::Serverless-2016-10-31"
           ]
         }
@@ -327,9 +330,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-acmpca-certificate.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ACMPCA::Certificate",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-acmpca-certificate.html",
         "type" : "string",
         "enum" : [ "AWS::ACMPCA::Certificate" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -372,9 +385,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-acmpca-certificateauthority.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ACMPCA::CertificateAuthority",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-acmpca-certificateauthority.html",
         "type" : "string",
         "enum" : [ "AWS::ACMPCA::CertificateAuthority" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -424,9 +447,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-acmpca-certificateauthorityactivation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ACMPCA::CertificateAuthorityActivation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-acmpca-certificateauthorityactivation.html",
         "type" : "string",
         "enum" : [ "AWS::ACMPCA::CertificateAuthorityActivation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -466,9 +499,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-accessanalyzer-analyzer.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AccessAnalyzer::Analyzer",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-accessanalyzer-analyzer.html",
         "type" : "string",
         "enum" : [ "AWS::AccessAnalyzer::Analyzer" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -517,9 +560,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amazonmq-broker.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AmazonMQ::Broker",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amazonmq-broker.html",
         "type" : "string",
         "enum" : [ "AWS::AmazonMQ::Broker" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -629,9 +682,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amazonmq-configuration.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AmazonMQ::Configuration",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amazonmq-configuration.html",
         "type" : "string",
         "enum" : [ "AWS::AmazonMQ::Configuration" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -683,9 +746,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amazonmq-configurationassociation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AmazonMQ::ConfigurationAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amazonmq-configurationassociation.html",
         "type" : "string",
         "enum" : [ "AWS::AmazonMQ::ConfigurationAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -716,9 +789,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amplify-app.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Amplify::App",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amplify-app.html",
         "type" : "string",
         "enum" : [ "AWS::Amplify::App" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -804,9 +887,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amplify-branch.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Amplify::Branch",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amplify-branch.html",
         "type" : "string",
         "enum" : [ "AWS::Amplify::Branch" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -837,6 +930,10 @@
           },
           "EnableAutoBuild" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amplify-branch.html#cfn-amplify-branch-enableautobuild",
+            "type" : [ "boolean", "object" ]
+          },
+          "EnablePerformanceMode" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amplify-branch.html#cfn-amplify-branch-enableperformancemode",
             "type" : [ "boolean", "object" ]
           },
           "BuildSpec" : {
@@ -881,9 +978,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amplify-domain.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Amplify::Domain",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amplify-domain.html",
         "type" : "string",
         "enum" : [ "AWS::Amplify::Domain" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -939,9 +1046,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-account.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGateway::Account",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-account.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGateway::Account" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -968,9 +1085,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-apikey.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGateway::ApiKey",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-apikey.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGateway::ApiKey" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -1034,9 +1161,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-authorizer.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGateway::Authorizer",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-authorizer.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGateway::Authorizer" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -1105,9 +1242,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-basepathmapping.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGateway::BasePathMapping",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-basepathmapping.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGateway::BasePathMapping" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -1147,9 +1294,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-clientcertificate.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGateway::ClientCertificate",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-clientcertificate.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGateway::ClientCertificate" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -1184,9 +1341,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-deployment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGateway::Deployment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-deployment.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGateway::Deployment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -1228,9 +1395,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-documentationpart.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGateway::DocumentationPart",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-documentationpart.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGateway::DocumentationPart" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -1265,9 +1442,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-documentationversion.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGateway::DocumentationVersion",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-documentationversion.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGateway::DocumentationVersion" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -1303,9 +1490,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-domainname.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGateway::DomainName",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-domainname.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGateway::DomainName" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -1358,9 +1555,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-gatewayresponse.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGateway::GatewayResponse",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-gatewayresponse.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGateway::GatewayResponse" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -1414,9 +1621,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-method.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGateway::Method",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-method.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGateway::Method" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -1511,9 +1728,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-model.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGateway::Model",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-model.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGateway::Model" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -1557,9 +1784,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-requestvalidator.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGateway::RequestValidator",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-requestvalidator.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGateway::RequestValidator" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -1599,9 +1836,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-resource.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGateway::Resource",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-resource.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGateway::Resource" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -1637,9 +1884,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGateway::RestApi",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGateway::RestApi" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -1726,9 +1983,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGateway::Stage",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGateway::Stage" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -1820,9 +2087,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-usageplan.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGateway::UsagePlan",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-usageplan.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGateway::UsagePlan" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -1876,9 +2153,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-usageplankey.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGateway::UsagePlanKey",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-usageplankey.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGateway::UsagePlanKey" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -1914,9 +2201,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-vpclink.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGateway::VpcLink",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-vpclink.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGateway::VpcLink" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -1956,9 +2253,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-api.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGatewayV2::Api",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-api.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGatewayV2::Api" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -2047,9 +2354,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-apigatewaymanagedoverrides.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGatewayV2::ApiGatewayManagedOverrides",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-apigatewaymanagedoverrides.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGatewayV2::ApiGatewayManagedOverrides" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -2086,9 +2403,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-apimapping.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGatewayV2::ApiMapping",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-apimapping.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGatewayV2::ApiMapping" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -2128,9 +2455,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-authorizer.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGatewayV2::Authorizer",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-authorizer.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGatewayV2::Authorizer" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -2201,9 +2538,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-deployment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGatewayV2::Deployment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-deployment.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGatewayV2::Deployment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -2239,9 +2586,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-domainname.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGatewayV2::DomainName",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-domainname.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGatewayV2::DomainName" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -2284,9 +2641,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-integration.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGatewayV2::Integration",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-integration.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGatewayV2::Integration" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -2377,9 +2744,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-integrationresponse.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGatewayV2::IntegrationResponse",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-integrationresponse.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGatewayV2::IntegrationResponse" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -2431,9 +2808,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-model.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGatewayV2::Model",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-model.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGatewayV2::Model" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -2477,9 +2864,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-route.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGatewayV2::Route",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-route.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGatewayV2::Route" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -2555,9 +2952,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-routeresponse.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGatewayV2::RouteResponse",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-routeresponse.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGatewayV2::RouteResponse" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -2605,9 +3012,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-stage.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGatewayV2::Stage",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-stage.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGatewayV2::Stage" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -2673,9 +3090,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-vpclink.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApiGatewayV2::VpcLink",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-vpclink.html",
         "type" : "string",
         "enum" : [ "AWS::ApiGatewayV2::VpcLink" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -2723,9 +3150,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appconfig-application.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppConfig::Application",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appconfig-application.html",
         "type" : "string",
         "enum" : [ "AWS::AppConfig::Application" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -2765,9 +3202,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appconfig-configurationprofile.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppConfig::ConfigurationProfile",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appconfig-configurationprofile.html",
         "type" : "string",
         "enum" : [ "AWS::AppConfig::ConfigurationProfile" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -2827,9 +3274,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appconfig-deployment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppConfig::Deployment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appconfig-deployment.html",
         "type" : "string",
         "enum" : [ "AWS::AppConfig::Deployment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -2885,9 +3342,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appconfig-deploymentstrategy.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppConfig::DeploymentStrategy",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appconfig-deploymentstrategy.html",
         "type" : "string",
         "enum" : [ "AWS::AppConfig::DeploymentStrategy" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -2947,9 +3414,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appconfig-environment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppConfig::Environment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appconfig-environment.html",
         "type" : "string",
         "enum" : [ "AWS::AppConfig::Environment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -3001,9 +3478,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appconfig-hostedconfigurationversion.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppConfig::HostedConfigurationVersion",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appconfig-hostedconfigurationversion.html",
         "type" : "string",
         "enum" : [ "AWS::AppConfig::HostedConfigurationVersion" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -3051,9 +3538,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appflow-connectorprofile.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppFlow::ConnectorProfile",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appflow-connectorprofile.html",
         "type" : "string",
         "enum" : [ "AWS::AppFlow::ConnectorProfile" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -3096,9 +3593,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appflow-flow.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppFlow::Flow",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appflow-flow.html",
         "type" : "string",
         "enum" : [ "AWS::AppFlow::Flow" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -3164,9 +3671,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-gatewayroute.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppMesh::GatewayRoute",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-gatewayroute.html",
         "type" : "string",
         "enum" : [ "AWS::AppMesh::GatewayRoute" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -3217,9 +3734,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-mesh.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppMesh::Mesh",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-mesh.html",
         "type" : "string",
         "enum" : [ "AWS::AppMesh::Mesh" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -3258,9 +3785,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-route.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppMesh::Route",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-route.html",
         "type" : "string",
         "enum" : [ "AWS::AppMesh::Route" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -3311,9 +3848,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-virtualgateway.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppMesh::VirtualGateway",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-virtualgateway.html",
         "type" : "string",
         "enum" : [ "AWS::AppMesh::VirtualGateway" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -3360,9 +3907,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-virtualnode.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppMesh::VirtualNode",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-virtualnode.html",
         "type" : "string",
         "enum" : [ "AWS::AppMesh::VirtualNode" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -3409,9 +3966,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-virtualrouter.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppMesh::VirtualRouter",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-virtualrouter.html",
         "type" : "string",
         "enum" : [ "AWS::AppMesh::VirtualRouter" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -3458,9 +4025,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-virtualservice.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppMesh::VirtualService",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appmesh-virtualservice.html",
         "type" : "string",
         "enum" : [ "AWS::AppMesh::VirtualService" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -3507,9 +4084,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-directoryconfig.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppStream::DirectoryConfig",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-directoryconfig.html",
         "type" : "string",
         "enum" : [ "AWS::AppStream::DirectoryConfig" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -3548,9 +4135,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-fleet.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppStream::Fleet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-fleet.html",
         "type" : "string",
         "enum" : [ "AWS::AppStream::Fleet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -3600,6 +4197,14 @@
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-fleet.html#cfn-appstream-fleet-displayname",
             "type" : [ "string", "object" ]
           },
+          "StreamView" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-fleet.html#cfn-appstream-fleet-streamview",
+            "type" : [ "string", "object" ]
+          },
+          "IamRoleArn" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-fleet.html#cfn-appstream-fleet-iamrolearn",
+            "type" : [ "string", "object" ]
+          },
           "InstanceType" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-fleet.html#cfn-appstream-fleet-instancetype",
             "type" : [ "string", "object" ]
@@ -3635,17 +4240,23 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-imagebuilder.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppStream::ImageBuilder",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-imagebuilder.html",
         "type" : "string",
         "enum" : [ "AWS::AppStream::ImageBuilder" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
         "properties" : {
-          "ImageName" : {
-            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-imagebuilder.html#cfn-appstream-imagebuilder-imagename",
-            "type" : [ "string", "object" ]
-          },
           "Description" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-imagebuilder.html#cfn-appstream-imagebuilder-description",
             "type" : [ "string", "object" ]
@@ -3657,15 +4268,27 @@
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-imagebuilder.html#cfn-appstream-imagebuilder-enabledefaultinternetaccess",
             "type" : [ "boolean", "object" ]
           },
-          "DisplayName" : {
-            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-imagebuilder.html#cfn-appstream-imagebuilder-displayname",
-            "type" : [ "string", "object" ]
-          },
           "DomainJoinInfo" : {
             "$ref" : "#/definitions/AWS_AppStream_ImageBuilder_DomainJoinInfo"
           },
           "AppstreamAgentVersion" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-imagebuilder.html#cfn-appstream-imagebuilder-appstreamagentversion",
+            "type" : [ "string", "object" ]
+          },
+          "Name" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-imagebuilder.html#cfn-appstream-imagebuilder-name",
+            "type" : [ "string", "object" ]
+          },
+          "ImageName" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-imagebuilder.html#cfn-appstream-imagebuilder-imagename",
+            "type" : [ "string", "object" ]
+          },
+          "DisplayName" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-imagebuilder.html#cfn-appstream-imagebuilder-displayname",
+            "type" : [ "string", "object" ]
+          },
+          "IamRoleArn" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-imagebuilder.html#cfn-appstream-imagebuilder-iamrolearn",
             "type" : [ "string", "object" ]
           },
           "InstanceType" : {
@@ -3680,10 +4303,6 @@
             },
             "minItems" : 0
           },
-          "Name" : {
-            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-imagebuilder.html#cfn-appstream-imagebuilder-name",
-            "type" : [ "string", "object" ]
-          },
           "ImageArn" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-imagebuilder.html#cfn-appstream-imagebuilder-imagearn",
             "type" : [ "string", "object" ]
@@ -3697,7 +4316,7 @@
             "minItems" : 0
           }
         },
-        "required" : [ "InstanceType", "Name" ],
+        "required" : [ "Name", "InstanceType" ],
         "additionalProperties" : false
       },
       "DependsOn" : {
@@ -3715,9 +4334,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-stack.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppStream::Stack",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-stack.html",
         "type" : "string",
         "enum" : [ "AWS::AppStream::Stack" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -3815,9 +4444,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-stackfleetassociation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppStream::StackFleetAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-stackfleetassociation.html",
         "type" : "string",
         "enum" : [ "AWS::AppStream::StackFleetAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -3849,9 +4488,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-stackuserassociation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppStream::StackUserAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-stackuserassociation.html",
         "type" : "string",
         "enum" : [ "AWS::AppStream::StackUserAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -3891,9 +4540,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-user.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppStream::User",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-user.html",
         "type" : "string",
         "enum" : [ "AWS::AppStream::User" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -3937,9 +4596,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-apicache.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppSync::ApiCache",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-apicache.html",
         "type" : "string",
         "enum" : [ "AWS::AppSync::ApiCache" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -3987,9 +4656,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-apikey.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppSync::ApiKey",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-apikey.html",
         "type" : "string",
         "enum" : [ "AWS::AppSync::ApiKey" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -4025,9 +4704,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-datasource.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppSync::DataSource",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-datasource.html",
         "type" : "string",
         "enum" : [ "AWS::AppSync::DataSource" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -4086,9 +4775,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppSync::FunctionConfiguration",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html",
         "type" : "string",
         "enum" : [ "AWS::AppSync::FunctionConfiguration" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -4148,9 +4847,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-graphqlapi.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppSync::GraphQLApi",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-graphqlapi.html",
         "type" : "string",
         "enum" : [ "AWS::AppSync::GraphQLApi" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -4201,9 +4910,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-graphqlschema.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppSync::GraphQLSchema",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-graphqlschema.html",
         "type" : "string",
         "enum" : [ "AWS::AppSync::GraphQLSchema" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -4239,9 +4958,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AppSync::Resolver",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html",
         "type" : "string",
         "enum" : [ "AWS::AppSync::Resolver" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -4310,9 +5039,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalabletarget.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApplicationAutoScaling::ScalableTarget",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalabletarget.html",
         "type" : "string",
         "enum" : [ "AWS::ApplicationAutoScaling::ScalableTarget" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -4372,9 +5111,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApplicationAutoScaling::ScalingPolicy",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html",
         "type" : "string",
         "enum" : [ "AWS::ApplicationAutoScaling::ScalingPolicy" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -4428,9 +5177,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationinsights-application.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ApplicationInsights::Application",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationinsights-application.html",
         "type" : "string",
         "enum" : [ "AWS::ApplicationInsights::Application" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -4506,9 +5265,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-athena-datacatalog.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Athena::DataCatalog",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-athena-datacatalog.html",
         "type" : "string",
         "enum" : [ "AWS::Athena::DataCatalog" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -4556,9 +5325,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-athena-namedquery.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Athena::NamedQuery",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-athena-namedquery.html",
         "type" : "string",
         "enum" : [ "AWS::Athena::NamedQuery" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -4598,9 +5377,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-athena-workgroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Athena::WorkGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-athena-workgroup.html",
         "type" : "string",
         "enum" : [ "AWS::Athena::WorkGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -4649,9 +5438,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AutoScaling::AutoScalingGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html",
         "type" : "string",
         "enum" : [ "AWS::AutoScaling::AutoScalingGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -4807,9 +5606,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AutoScaling::LaunchConfiguration",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html",
         "type" : "string",
         "enum" : [ "AWS::AutoScaling::LaunchConfiguration" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -4920,9 +5729,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AutoScaling::LifecycleHook",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html",
         "type" : "string",
         "enum" : [ "AWS::AutoScaling::LifecycleHook" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -4978,9 +5797,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AutoScaling::ScalingPolicy",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html",
         "type" : "string",
         "enum" : [ "AWS::AutoScaling::ScalingPolicy" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5048,9 +5877,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-scheduledaction.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AutoScaling::ScheduledAction",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-scheduledaction.html",
         "type" : "string",
         "enum" : [ "AWS::AutoScaling::ScheduledAction" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5102,9 +5941,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-autoscalingplans-scalingplan.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::AutoScalingPlans::ScalingPlan",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-autoscalingplans-scalingplan.html",
         "type" : "string",
         "enum" : [ "AWS::AutoScalingPlans::ScalingPlan" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5139,9 +5988,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-backup-backupplan.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Backup::BackupPlan",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-backup-backupplan.html",
         "type" : "string",
         "enum" : [ "AWS::Backup::BackupPlan" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5171,9 +6030,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-backup-backupselection.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Backup::BackupSelection",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-backup-backupselection.html",
         "type" : "string",
         "enum" : [ "AWS::Backup::BackupSelection" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5204,9 +6073,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-backup-backupvault.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Backup::BackupVault",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-backup-backupvault.html",
         "type" : "string",
         "enum" : [ "AWS::Backup::BackupVault" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5249,9 +6128,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-computeenvironment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Batch::ComputeEnvironment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-computeenvironment.html",
         "type" : "string",
         "enum" : [ "AWS::Batch::ComputeEnvironment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5294,9 +6183,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobdefinition.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Batch::JobDefinition",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobdefinition.html",
         "type" : "string",
         "enum" : [ "AWS::Batch::JobDefinition" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5344,9 +6243,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobqueue.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Batch::JobQueue",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobqueue.html",
         "type" : "string",
         "enum" : [ "AWS::Batch::JobQueue" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5390,9 +6299,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-budgets-budget.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Budgets::Budget",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-budgets-budget.html",
         "type" : "string",
         "enum" : [ "AWS::Budgets::Budget" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5426,9 +6345,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ce-costcategory.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CE::CostCategory",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ce-costcategory.html",
         "type" : "string",
         "enum" : [ "AWS::CE::CostCategory" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5464,9 +6393,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cassandra-keyspace.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Cassandra::Keyspace",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cassandra-keyspace.html",
         "type" : "string",
         "enum" : [ "AWS::Cassandra::Keyspace" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5493,9 +6432,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cassandra-table.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Cassandra::Table",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cassandra-table.html",
         "type" : "string",
         "enum" : [ "AWS::Cassandra::Table" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5557,9 +6506,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CertificateManager::Certificate",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
         "type" : "string",
         "enum" : [ "AWS::CertificateManager::Certificate" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5625,9 +6584,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-chatbot-slackchannelconfiguration.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Chatbot::SlackChannelConfiguration",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-chatbot-slackchannelconfiguration.html",
         "type" : "string",
         "enum" : [ "AWS::Chatbot::SlackChannelConfiguration" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5679,9 +6648,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloud9-environmentec2.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Cloud9::EnvironmentEC2",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloud9-environmentec2.html",
         "type" : "string",
         "enum" : [ "AWS::Cloud9::EnvironmentEC2" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5749,9 +6728,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cfn-customresource.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CloudFormation::CustomResource",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cfn-customresource.html",
         "type" : "string",
         "enum" : [ "AWS::CloudFormation::CustomResource" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5779,9 +6768,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-macro.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CloudFormation::Macro",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-macro.html",
         "type" : "string",
         "enum" : [ "AWS::CloudFormation::Macro" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5825,9 +6824,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stack.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CloudFormation::Stack",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stack.html",
         "type" : "string",
         "enum" : [ "AWS::CloudFormation::Stack" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5885,9 +6894,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-stackset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CloudFormation::StackSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-stackset.html",
         "type" : "string",
         "enum" : [ "AWS::CloudFormation::StackSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -5980,9 +6999,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-waitcondition.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CloudFormation::WaitCondition",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-waitcondition.html",
         "type" : "string",
         "enum" : [ "AWS::CloudFormation::WaitCondition" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6017,9 +7046,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-waitconditionhandle.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CloudFormation::WaitConditionHandle",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-waitconditionhandle.html",
         "type" : "string",
         "enum" : [ "AWS::CloudFormation::WaitConditionHandle" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6041,9 +7080,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-cachepolicy.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CloudFront::CachePolicy",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-cachepolicy.html",
         "type" : "string",
         "enum" : [ "AWS::CloudFront::CachePolicy" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6069,9 +7118,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-cloudfrontoriginaccessidentity.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CloudFront::CloudFrontOriginAccessIdentity",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-cloudfrontoriginaccessidentity.html",
         "type" : "string",
         "enum" : [ "AWS::CloudFront::CloudFrontOriginAccessIdentity" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6097,9 +7156,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-distribution.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CloudFront::Distribution",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-distribution.html",
         "type" : "string",
         "enum" : [ "AWS::CloudFront::Distribution" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6133,9 +7202,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-originrequestpolicy.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CloudFront::OriginRequestPolicy",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-originrequestpolicy.html",
         "type" : "string",
         "enum" : [ "AWS::CloudFront::OriginRequestPolicy" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6161,9 +7240,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-realtimelogconfig.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CloudFront::RealtimeLogConfig",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-realtimelogconfig.html",
         "type" : "string",
         "enum" : [ "AWS::CloudFront::RealtimeLogConfig" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6211,9 +7300,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-streamingdistribution.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CloudFront::StreamingDistribution",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-streamingdistribution.html",
         "type" : "string",
         "enum" : [ "AWS::CloudFront::StreamingDistribution" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6248,9 +7347,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudtrail-trail.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CloudTrail::Trail",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudtrail-trail.html",
         "type" : "string",
         "enum" : [ "AWS::CloudTrail::Trail" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6335,9 +7444,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CloudWatch::Alarm",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html",
         "type" : "string",
         "enum" : [ "AWS::CloudWatch::Alarm" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6466,9 +7585,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudwatch-anomalydetector.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CloudWatch::AnomalyDetector",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudwatch-anomalydetector.html",
         "type" : "string",
         "enum" : [ "AWS::CloudWatch::AnomalyDetector" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6515,9 +7644,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudwatch-compositealarm.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CloudWatch::CompositeAlarm",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudwatch-compositealarm.html",
         "type" : "string",
         "enum" : [ "AWS::CloudWatch::CompositeAlarm" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6581,9 +7720,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudwatch-dashboard.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CloudWatch::Dashboard",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudwatch-dashboard.html",
         "type" : "string",
         "enum" : [ "AWS::CloudWatch::Dashboard" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6615,9 +7764,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudwatch-insightrule.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CloudWatch::InsightRule",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudwatch-insightrule.html",
         "type" : "string",
         "enum" : [ "AWS::CloudWatch::InsightRule" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6656,9 +7815,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codebuild-project.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CodeBuild::Project",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codebuild-project.html",
         "type" : "string",
         "enum" : [ "AWS::CodeBuild::Project" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6778,9 +7947,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codebuild-reportgroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CodeBuild::ReportGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codebuild-reportgroup.html",
         "type" : "string",
         "enum" : [ "AWS::CodeBuild::ReportGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6827,9 +8006,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codebuild-sourcecredential.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CodeBuild::SourceCredential",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codebuild-sourcecredential.html",
         "type" : "string",
         "enum" : [ "AWS::CodeBuild::SourceCredential" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6869,9 +8058,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codecommit-repository.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CodeCommit::Repository",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codecommit-repository.html",
         "type" : "string",
         "enum" : [ "AWS::CodeCommit::Repository" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6922,9 +8121,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CodeDeploy::Application",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html",
         "type" : "string",
         "enum" : [ "AWS::CodeDeploy::Application" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6955,9 +8164,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-deploymentconfig.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CodeDeploy::DeploymentConfig",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-deploymentconfig.html",
         "type" : "string",
         "enum" : [ "AWS::CodeDeploy::DeploymentConfig" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -6987,9 +8206,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-deploymentgroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CodeDeploy::DeploymentGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-deploymentgroup.html",
         "type" : "string",
         "enum" : [ "AWS::CodeDeploy::DeploymentGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -7086,9 +8315,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codeguruprofiler-profilinggroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CodeGuruProfiler::ProfilingGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codeguruprofiler-profilinggroup.html",
         "type" : "string",
         "enum" : [ "AWS::CodeGuruProfiler::ProfilingGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -7141,9 +8380,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codegurureviewer-repositoryassociation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CodeGuruReviewer::RepositoryAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codegurureviewer-repositoryassociation.html",
         "type" : "string",
         "enum" : [ "AWS::CodeGuruReviewer::RepositoryAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -7183,9 +8432,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CodePipeline::CustomActionType",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html",
         "type" : "string",
         "enum" : [ "AWS::CodePipeline::CustomActionType" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -7247,9 +8506,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-pipeline.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CodePipeline::Pipeline",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-pipeline.html",
         "type" : "string",
         "enum" : [ "AWS::CodePipeline::Pipeline" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -7323,9 +8592,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CodePipeline::Webhook",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html",
         "type" : "string",
         "enum" : [ "AWS::CodePipeline::Webhook" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -7384,9 +8663,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codestar-githubrepository.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CodeStar::GitHubRepository",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codestar-githubrepository.html",
         "type" : "string",
         "enum" : [ "AWS::CodeStar::GitHubRepository" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -7437,9 +8726,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codestarconnections-connection.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CodeStarConnections::Connection",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codestarconnections-connection.html",
         "type" : "string",
         "enum" : [ "AWS::CodeStarConnections::Connection" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -7483,9 +8782,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codestarnotifications-notificationrule.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::CodeStarNotifications::NotificationRule",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codestarnotifications-notificationrule.html",
         "type" : "string",
         "enum" : [ "AWS::CodeStarNotifications::NotificationRule" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -7545,9 +8854,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-identitypool.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Cognito::IdentityPool",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-identitypool.html",
         "type" : "string",
         "enum" : [ "AWS::Cognito::IdentityPool" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -7625,9 +8944,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-identitypoolroleattachment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Cognito::IdentityPoolRoleAttachment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-identitypoolroleattachment.html",
         "type" : "string",
         "enum" : [ "AWS::Cognito::IdentityPoolRoleAttachment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -7663,9 +8992,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Cognito::UserPool",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html",
         "type" : "string",
         "enum" : [ "AWS::Cognito::UserPool" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -7786,9 +9125,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolclient.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Cognito::UserPoolClient",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolclient.html",
         "type" : "string",
         "enum" : [ "AWS::Cognito::UserPoolClient" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -7918,9 +9267,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpooldomain.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Cognito::UserPoolDomain",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpooldomain.html",
         "type" : "string",
         "enum" : [ "AWS::Cognito::UserPoolDomain" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -7955,9 +9314,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolgroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Cognito::UserPoolGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolgroup.html",
         "type" : "string",
         "enum" : [ "AWS::Cognito::UserPoolGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8001,9 +9370,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolidentityprovider.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Cognito::UserPoolIdentityProvider",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolidentityprovider.html",
         "type" : "string",
         "enum" : [ "AWS::Cognito::UserPoolIdentityProvider" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8055,9 +9434,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolresourceserver.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Cognito::UserPoolResourceServer",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolresourceserver.html",
         "type" : "string",
         "enum" : [ "AWS::Cognito::UserPoolResourceServer" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8101,9 +9490,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolriskconfigurationattachment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Cognito::UserPoolRiskConfigurationAttachment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolriskconfigurationattachment.html",
         "type" : "string",
         "enum" : [ "AWS::Cognito::UserPoolRiskConfigurationAttachment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8144,9 +9543,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpooluicustomizationattachment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Cognito::UserPoolUICustomizationAttachment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpooluicustomizationattachment.html",
         "type" : "string",
         "enum" : [ "AWS::Cognito::UserPoolUICustomizationAttachment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8182,9 +9591,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpooluser.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Cognito::UserPoolUser",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpooluser.html",
         "type" : "string",
         "enum" : [ "AWS::Cognito::UserPoolUser" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8252,9 +9671,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolusertogroupattachment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Cognito::UserPoolUserToGroupAttachment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolusertogroupattachment.html",
         "type" : "string",
         "enum" : [ "AWS::Cognito::UserPoolUserToGroupAttachment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8290,9 +9719,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-aggregationauthorization.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Config::AggregationAuthorization",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-aggregationauthorization.html",
         "type" : "string",
         "enum" : [ "AWS::Config::AggregationAuthorization" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8332,9 +9771,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-configrule.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Config::ConfigRule",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-configrule.html",
         "type" : "string",
         "enum" : [ "AWS::Config::ConfigRule" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8379,9 +9828,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-configurationaggregator.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Config::ConfigurationAggregator",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-configurationaggregator.html",
         "type" : "string",
         "enum" : [ "AWS::Config::ConfigurationAggregator" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8428,9 +9887,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-configurationrecorder.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Config::ConfigurationRecorder",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-configurationrecorder.html",
         "type" : "string",
         "enum" : [ "AWS::Config::ConfigurationRecorder" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8465,9 +9934,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-conformancepack.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Config::ConformancePack",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-conformancepack.html",
         "type" : "string",
         "enum" : [ "AWS::Config::ConformancePack" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8519,9 +9998,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-deliverychannel.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Config::DeliveryChannel",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-deliverychannel.html",
         "type" : "string",
         "enum" : [ "AWS::Config::DeliveryChannel" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8564,9 +10053,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-organizationconfigrule.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Config::OrganizationConfigRule",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-organizationconfigrule.html",
         "type" : "string",
         "enum" : [ "AWS::Config::OrganizationConfigRule" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8608,9 +10107,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-organizationconformancepack.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Config::OrganizationConformancePack",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-organizationconformancepack.html",
         "type" : "string",
         "enum" : [ "AWS::Config::OrganizationConformancePack" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8670,9 +10179,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-remediationconfiguration.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Config::RemediationConfiguration",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-remediationconfiguration.html",
         "type" : "string",
         "enum" : [ "AWS::Config::RemediationConfiguration" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8735,9 +10254,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dax-cluster.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::DAX::Cluster",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dax-cluster.html",
         "type" : "string",
         "enum" : [ "AWS::DAX::Cluster" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8820,9 +10349,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dax-parametergroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::DAX::ParameterGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dax-parametergroup.html",
         "type" : "string",
         "enum" : [ "AWS::DAX::ParameterGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8857,9 +10396,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dax-subnetgroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::DAX::SubnetGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dax-subnetgroup.html",
         "type" : "string",
         "enum" : [ "AWS::DAX::SubnetGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8899,9 +10448,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dlm-lifecyclepolicy.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::DLM::LifecyclePolicy",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dlm-lifecyclepolicy.html",
         "type" : "string",
         "enum" : [ "AWS::DLM::LifecyclePolicy" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8939,9 +10498,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-certificate.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::DMS::Certificate",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-certificate.html",
         "type" : "string",
         "enum" : [ "AWS::DMS::Certificate" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -8976,9 +10545,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-endpoint.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::DMS::Endpoint",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-endpoint.html",
         "type" : "string",
         "enum" : [ "AWS::DMS::Endpoint" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -9079,9 +10658,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-eventsubscription.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::DMS::EventSubscription",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-eventsubscription.html",
         "type" : "string",
         "enum" : [ "AWS::DMS::EventSubscription" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -9145,9 +10734,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-replicationinstance.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::DMS::ReplicationInstance",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-replicationinstance.html",
         "type" : "string",
         "enum" : [ "AWS::DMS::ReplicationInstance" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -9235,9 +10834,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-replicationsubnetgroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::DMS::ReplicationSubnetGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-replicationsubnetgroup.html",
         "type" : "string",
         "enum" : [ "AWS::DMS::ReplicationSubnetGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -9285,9 +10894,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-replicationtask.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::DMS::ReplicationTask",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-replicationtask.html",
         "type" : "string",
         "enum" : [ "AWS::DMS::ReplicationTask" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -9363,9 +10982,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-datapipeline-pipeline.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::DataPipeline::Pipeline",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-datapipeline-pipeline.html",
         "type" : "string",
         "enum" : [ "AWS::DataPipeline::Pipeline" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -9433,9 +11062,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-detective-graph.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Detective::Graph",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-detective-graph.html",
         "type" : "string",
         "enum" : [ "AWS::Detective::Graph" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -9457,9 +11096,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-detective-memberinvitation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Detective::MemberInvitation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-detective-memberinvitation.html",
         "type" : "string",
         "enum" : [ "AWS::Detective::MemberInvitation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -9499,9 +11148,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-directoryservice-microsoftad.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::DirectoryService::MicrosoftAD",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-directoryservice-microsoftad.html",
         "type" : "string",
         "enum" : [ "AWS::DirectoryService::MicrosoftAD" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -9552,9 +11211,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-directoryservice-simplead.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::DirectoryService::SimpleAD",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-directoryservice-simplead.html",
         "type" : "string",
         "enum" : [ "AWS::DirectoryService::SimpleAD" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -9609,9 +11278,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-docdb-dbcluster.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::DocDB::DBCluster",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-docdb-dbcluster.html",
         "type" : "string",
         "enum" : [ "AWS::DocDB::DBCluster" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -9723,9 +11402,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-docdb-dbclusterparametergroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::DocDB::DBClusterParameterGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-docdb-dbclusterparametergroup.html",
         "type" : "string",
         "enum" : [ "AWS::DocDB::DBClusterParameterGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -9773,9 +11462,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-docdb-dbinstance.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::DocDB::DBInstance",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-docdb-dbinstance.html",
         "type" : "string",
         "enum" : [ "AWS::DocDB::DBInstance" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -9831,9 +11530,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-docdb-dbsubnetgroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::DocDB::DBSubnetGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-docdb-dbsubnetgroup.html",
         "type" : "string",
         "enum" : [ "AWS::DocDB::DBSubnetGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -9881,9 +11590,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::DynamoDB::Table",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html",
         "type" : "string",
         "enum" : [ "AWS::DynamoDB::Table" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -9971,9 +11690,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::CapacityReservation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::CapacityReservation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -10045,9 +11774,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-carriergateway.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::CarrierGateway",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-carriergateway.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::CarrierGateway" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -10078,9 +11817,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-clientvpnauthorizationrule.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::ClientVpnAuthorizationRule",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-clientvpnauthorizationrule.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::ClientVpnAuthorizationRule" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -10124,9 +11873,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-clientvpnendpoint.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::ClientVpnEndpoint",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-clientvpnendpoint.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::ClientVpnEndpoint" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -10213,9 +11972,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-clientvpnroute.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::ClientVpnRoute",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-clientvpnroute.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::ClientVpnRoute" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -10255,9 +12024,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-clientvpntargetnetworkassociation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::ClientVpnTargetNetworkAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-clientvpntargetnetworkassociation.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::ClientVpnTargetNetworkAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -10289,9 +12068,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::CustomerGateway",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::CustomerGateway" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -10335,9 +12124,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::DHCPOptions",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::DHCPOptions" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -10402,9 +12201,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::EC2Fleet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::EC2Fleet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -10477,9 +12286,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-eip.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::EIP",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-eip.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::EIP" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -10522,9 +12341,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-eip-association.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::EIPAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-eip-association.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::EIPAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -10567,9 +12396,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-egressonlyinternetgateway.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::EgressOnlyInternetGateway",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-egressonlyinternetgateway.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::EgressOnlyInternetGateway" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -10597,9 +12436,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-flowlog.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::FlowLog",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-flowlog.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::FlowLog" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -10667,9 +12516,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-gatewayroutetableassociation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::GatewayRouteTableAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-gatewayroutetableassociation.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::GatewayRouteTableAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -10701,9 +12560,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::Host",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::Host" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -10743,9 +12612,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::Instance",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::Instance" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -10959,9 +12838,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-internetgateway.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::InternetGateway",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-internetgateway.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::InternetGateway" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -10992,9 +12881,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::LaunchTemplate",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::LaunchTemplate" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11024,9 +12923,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-localgatewayroute.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::LocalGatewayRoute",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-localgatewayroute.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::LocalGatewayRoute" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11062,9 +12971,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-localgatewayroutetablevpcassociation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::LocalGatewayRouteTableVPCAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-localgatewayroutetablevpcassociation.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::LocalGatewayRouteTableVPCAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11099,9 +13018,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-natgateway.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::NatGateway",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-natgateway.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::NatGateway" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11141,9 +13070,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::NetworkAcl",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::NetworkAcl" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11179,9 +13118,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::NetworkAclEntry",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::NetworkAclEntry" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11239,9 +13188,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-interface.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::NetworkInterface",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-interface.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::NetworkInterface" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11328,9 +13287,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-interface-attachment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::NetworkInterfaceAttachment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-interface-attachment.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::NetworkInterfaceAttachment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11370,9 +13339,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::NetworkInterfacePermission",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::NetworkInterfacePermission" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11408,9 +13387,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::PlacementGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::PlacementGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11437,9 +13426,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-prefixlist.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::PrefixList",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-prefixlist.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::PrefixList" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11491,9 +13490,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-route.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::Route",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-route.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::Route" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11557,9 +13566,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-route-table.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::RouteTable",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-route-table.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::RouteTable" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11595,9 +13614,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::SecurityGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::SecurityGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11657,9 +13686,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-security-group-egress.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::SecurityGroupEgress",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-security-group-egress.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::SecurityGroupEgress" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11719,9 +13758,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group-ingress.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::SecurityGroupIngress",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group-ingress.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::SecurityGroupIngress" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11793,9 +13842,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-spotfleet.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::SpotFleet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-spotfleet.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::SpotFleet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11821,9 +13880,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnet.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::Subnet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnet.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::Subnet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11879,9 +13948,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnetcidrblock.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::SubnetCidrBlock",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnetcidrblock.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::SubnetCidrBlock" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11913,9 +13992,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnet-network-acl-assoc.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::SubnetNetworkAclAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnet-network-acl-assoc.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::SubnetNetworkAclAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11947,9 +14036,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnet-route-table-assoc.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::SubnetRouteTableAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnet-route-table-assoc.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::SubnetRouteTableAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -11981,9 +14080,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-trafficmirrorfilter.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::TrafficMirrorFilter",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-trafficmirrorfilter.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::TrafficMirrorFilter" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12026,9 +14135,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-trafficmirrorfilterrule.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::TrafficMirrorFilterRule",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-trafficmirrorfilterrule.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::TrafficMirrorFilterRule" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12090,9 +14209,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-trafficmirrorsession.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::TrafficMirrorSession",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-trafficmirrorsession.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::TrafficMirrorSession" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12152,9 +14281,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-trafficmirrortarget.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::TrafficMirrorTarget",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-trafficmirrortarget.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::TrafficMirrorTarget" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12197,9 +14336,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-transitgateway.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::TransitGateway",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-transitgateway.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::TransitGateway" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12262,9 +14411,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-transitgatewayattachment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::TransitGatewayAttachment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-transitgatewayattachment.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::TransitGatewayAttachment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12312,9 +14471,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-transitgatewayroute.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::TransitGatewayRoute",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-transitgatewayroute.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::TransitGatewayRoute" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12354,9 +14523,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-transitgatewayroutetable.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::TransitGatewayRouteTable",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-transitgatewayroutetable.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::TransitGatewayRouteTable" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12392,9 +14571,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-transitgatewayroutetableassociation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::TransitGatewayRouteTableAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-transitgatewayroutetableassociation.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::TransitGatewayRouteTableAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12426,9 +14615,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-transitgatewayroutetablepropagation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::TransitGatewayRouteTablePropagation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-transitgatewayroutetablepropagation.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::TransitGatewayRouteTablePropagation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12460,9 +14659,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::VPC",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::VPC" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12510,9 +14719,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpccidrblock.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::VPCCidrBlock",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpccidrblock.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::VPCCidrBlock" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12548,9 +14767,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc-dhcp-options-assoc.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::VPCDHCPOptionsAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc-dhcp-options-assoc.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::VPCDHCPOptionsAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12582,9 +14811,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcendpoint.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::VPCEndpoint",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcendpoint.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::VPCEndpoint" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12655,9 +14894,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcendpointconnectionnotification.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::VPCEndpointConnectionNotification",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcendpointconnectionnotification.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::VPCEndpointConnectionNotification" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12701,9 +14950,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcendpointservice.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::VPCEndpointService",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcendpointservice.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::VPCEndpointService" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12746,9 +15005,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcendpointservicepermissions.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::VPCEndpointServicePermissions",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcendpointservicepermissions.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::VPCEndpointServicePermissions" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12784,9 +15053,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc-gateway-attachment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::VPCGatewayAttachment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc-gateway-attachment.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::VPCGatewayAttachment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12822,9 +15101,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcpeeringconnection.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::VPCPeeringConnection",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcpeeringconnection.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::VPCPeeringConnection" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12876,9 +15165,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpn-connection.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::VPNConnection",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpn-connection.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::VPNConnection" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12939,9 +15238,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpn-connection-route.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::VPNConnectionRoute",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpn-connection-route.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::VPNConnectionRoute" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -12973,9 +15282,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpn-gateway.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::VPNGateway",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpn-gateway.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::VPNGateway" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -13015,9 +15334,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpn-gatewayrouteprop.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::VPNGatewayRoutePropagation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpn-gatewayrouteprop.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::VPNGatewayRoutePropagation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -13053,9 +15382,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ebs-volume.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::Volume",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ebs-volume.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::Volume" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -13127,9 +15466,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ebs-volumeattachment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EC2::VolumeAttachment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ebs-volumeattachment.html",
         "type" : "string",
         "enum" : [ "AWS::EC2::VolumeAttachment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -13165,9 +15514,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecr-repository.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ECR::Repository",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecr-repository.html",
         "type" : "string",
         "enum" : [ "AWS::ECR::Repository" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -13223,9 +15582,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-capacityprovider.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ECS::CapacityProvider",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-capacityprovider.html",
         "type" : "string",
         "enum" : [ "AWS::ECS::CapacityProvider" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -13263,9 +15632,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-cluster.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ECS::Cluster",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-cluster.html",
         "type" : "string",
         "enum" : [ "AWS::ECS::Cluster" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -13324,9 +15703,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-primarytaskset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ECS::PrimaryTaskSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-primarytaskset.html",
         "type" : "string",
         "enum" : [ "AWS::ECS::PrimaryTaskSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -13362,9 +15751,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-service.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ECS::Service",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-service.html",
         "type" : "string",
         "enum" : [ "AWS::ECS::Service" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -13492,9 +15891,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ECS::TaskDefinition",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html",
         "type" : "string",
         "enum" : [ "AWS::ECS::TaskDefinition" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -13605,9 +16014,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ECS::TaskSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskset.html",
         "type" : "string",
         "enum" : [ "AWS::ECS::TaskSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -13677,9 +16096,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-accesspoint.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EFS::AccessPoint",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-accesspoint.html",
         "type" : "string",
         "enum" : [ "AWS::EFS::AccessPoint" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -13726,9 +16155,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-filesystem.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EFS::FileSystem",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-filesystem.html",
         "type" : "string",
         "enum" : [ "AWS::EFS::FileSystem" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -13796,9 +16235,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-mounttarget.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EFS::MountTarget",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-mounttarget.html",
         "type" : "string",
         "enum" : [ "AWS::EFS::MountTarget" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -13843,9 +16292,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EKS::Cluster",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html",
         "type" : "string",
         "enum" : [ "AWS::EKS::Cluster" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -13868,6 +16327,9 @@
           },
           "ResourcesVpcConfig" : {
             "$ref" : "#/definitions/AWS_EKS_Cluster_ResourcesVpcConfig"
+          },
+          "KubernetesNetworkConfig" : {
+            "$ref" : "#/definitions/AWS_EKS_Cluster_KubernetesNetworkConfig"
           },
           "Name" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-name",
@@ -13892,9 +16354,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EKS::FargateProfile",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html",
         "type" : "string",
         "enum" : [ "AWS::EKS::FargateProfile" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -13955,9 +16427,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EKS::Nodegroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html",
         "type" : "string",
         "enum" : [ "AWS::EKS::Nodegroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -14046,9 +16528,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticmapreduce-cluster.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EMR::Cluster",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticmapreduce-cluster.html",
         "type" : "string",
         "enum" : [ "AWS::EMR::Cluster" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -14170,9 +16662,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticmapreduce-instancefleetconfig.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EMR::InstanceFleetConfig",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticmapreduce-instancefleetconfig.html",
         "type" : "string",
         "enum" : [ "AWS::EMR::InstanceFleetConfig" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -14228,9 +16730,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-emr-instancegroupconfig.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EMR::InstanceGroupConfig",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-emr-instancegroupconfig.html",
         "type" : "string",
         "enum" : [ "AWS::EMR::InstanceGroupConfig" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -14297,9 +16809,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-emr-securityconfiguration.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EMR::SecurityConfiguration",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-emr-securityconfiguration.html",
         "type" : "string",
         "enum" : [ "AWS::EMR::SecurityConfiguration" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -14331,9 +16853,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-emr-step.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EMR::Step",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-emr-step.html",
         "type" : "string",
         "enum" : [ "AWS::EMR::Step" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -14372,9 +16904,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-cache-cluster.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ElastiCache::CacheCluster",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-cache-cluster.html",
         "type" : "string",
         "enum" : [ "AWS::ElastiCache::CacheCluster" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -14504,9 +17046,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-parameter-group.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ElastiCache::ParameterGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-parameter-group.html",
         "type" : "string",
         "enum" : [ "AWS::ElastiCache::ParameterGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -14547,9 +17099,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-replicationgroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ElastiCache::ReplicationGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-replicationgroup.html",
         "type" : "string",
         "enum" : [ "AWS::ElastiCache::ReplicationGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -14726,9 +17288,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-security-group.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ElastiCache::SecurityGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-security-group.html",
         "type" : "string",
         "enum" : [ "AWS::ElastiCache::SecurityGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -14756,9 +17328,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-security-group-ingress.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ElastiCache::SecurityGroupIngress",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-security-group-ingress.html",
         "type" : "string",
         "enum" : [ "AWS::ElastiCache::SecurityGroupIngress" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -14794,9 +17376,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-subnetgroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ElastiCache::SubnetGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-subnetgroup.html",
         "type" : "string",
         "enum" : [ "AWS::ElastiCache::SubnetGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -14836,9 +17428,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-beanstalk.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ElasticBeanstalk::Application",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-beanstalk.html",
         "type" : "string",
         "enum" : [ "AWS::ElasticBeanstalk::Application" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -14872,9 +17474,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-beanstalk-version.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ElasticBeanstalk::ApplicationVersion",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-beanstalk-version.html",
         "type" : "string",
         "enum" : [ "AWS::ElasticBeanstalk::ApplicationVersion" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -14909,9 +17521,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticbeanstalk-configurationtemplate.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ElasticBeanstalk::ConfigurationTemplate",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticbeanstalk-configurationtemplate.html",
         "type" : "string",
         "enum" : [ "AWS::ElasticBeanstalk::ConfigurationTemplate" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -14966,9 +17588,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-beanstalk-environment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ElasticBeanstalk::Environment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-beanstalk-environment.html",
         "type" : "string",
         "enum" : [ "AWS::ElasticBeanstalk::Environment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -15043,9 +17675,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ElasticLoadBalancing::LoadBalancer",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb.html",
         "type" : "string",
         "enum" : [ "AWS::ElasticLoadBalancing::LoadBalancer" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -15173,9 +17815,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-listener.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ElasticLoadBalancingV2::Listener",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-listener.html",
         "type" : "string",
         "enum" : [ "AWS::ElasticLoadBalancingV2::Listener" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -15242,9 +17894,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-listenercertificate.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ElasticLoadBalancingV2::ListenerCertificate",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-listenercertificate.html",
         "type" : "string",
         "enum" : [ "AWS::ElasticLoadBalancingV2::ListenerCertificate" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -15281,9 +17943,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-listenerrule.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ElasticLoadBalancingV2::ListenerRule",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-listenerrule.html",
         "type" : "string",
         "enum" : [ "AWS::ElasticLoadBalancingV2::ListenerRule" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -15333,9 +18005,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-loadbalancer.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ElasticLoadBalancingV2::LoadBalancer",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-loadbalancer.html",
         "type" : "string",
         "enum" : [ "AWS::ElasticLoadBalancingV2::LoadBalancer" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -15418,9 +18100,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ElasticLoadBalancingV2::TargetGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html",
         "type" : "string",
         "enum" : [ "AWS::ElasticLoadBalancingV2::TargetGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -15524,9 +18216,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticsearch-domain.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Elasticsearch::Domain",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticsearch-domain.html",
         "type" : "string",
         "enum" : [ "AWS::Elasticsearch::Domain" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -15614,9 +18316,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-discoverer.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EventSchemas::Discoverer",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-discoverer.html",
         "type" : "string",
         "enum" : [ "AWS::EventSchemas::Discoverer" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -15656,9 +18368,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-registry.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EventSchemas::Registry",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-registry.html",
         "type" : "string",
         "enum" : [ "AWS::EventSchemas::Registry" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -15697,9 +18419,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-registrypolicy.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EventSchemas::RegistryPolicy",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-registrypolicy.html",
         "type" : "string",
         "enum" : [ "AWS::EventSchemas::RegistryPolicy" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -15735,9 +18467,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-schema.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::EventSchemas::Schema",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-schema.html",
         "type" : "string",
         "enum" : [ "AWS::EventSchemas::Schema" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -15789,9 +18531,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Events::EventBus",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html",
         "type" : "string",
         "enum" : [ "AWS::Events::EventBus" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -15823,9 +18575,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Events::EventBusPolicy",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html",
         "type" : "string",
         "enum" : [ "AWS::Events::EventBusPolicy" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -15868,9 +18630,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Events::Rule",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html",
         "type" : "string",
         "enum" : [ "AWS::Events::Rule" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -15930,9 +18702,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fms-notificationchannel.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::FMS::NotificationChannel",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fms-notificationchannel.html",
         "type" : "string",
         "enum" : [ "AWS::FMS::NotificationChannel" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -15964,9 +18746,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fms-policy.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::FMS::Policy",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fms-policy.html",
         "type" : "string",
         "enum" : [ "AWS::FMS::Policy" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -16044,9 +18836,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fsx-filesystem.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::FSx::FileSystem",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fsx-filesystem.html",
         "type" : "string",
         "enum" : [ "AWS::FSx::FileSystem" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -16120,9 +18922,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-gamelift-alias.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::GameLift::Alias",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-gamelift-alias.html",
         "type" : "string",
         "enum" : [ "AWS::GameLift::Alias" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -16157,9 +18969,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-gamelift-build.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::GameLift::Build",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-gamelift-build.html",
         "type" : "string",
         "enum" : [ "AWS::GameLift::Build" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -16197,9 +19019,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-gamelift-fleet.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::GameLift::Fleet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-gamelift-fleet.html",
         "type" : "string",
         "enum" : [ "AWS::GameLift::Fleet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -16319,9 +19151,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-gamelift-gameservergroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::GameLift::GameServerGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-gamelift-gameservergroup.html",
         "type" : "string",
         "enum" : [ "AWS::GameLift::GameServerGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -16388,9 +19230,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-gamelift-gamesessionqueue.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::GameLift::GameSessionQueue",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-gamelift-gamesessionqueue.html",
         "type" : "string",
         "enum" : [ "AWS::GameLift::GameSessionQueue" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -16438,9 +19290,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-gamelift-matchmakingconfiguration.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::GameLift::MatchmakingConfiguration",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-gamelift-matchmakingconfiguration.html",
         "type" : "string",
         "enum" : [ "AWS::GameLift::MatchmakingConfiguration" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -16524,9 +19386,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-gamelift-matchmakingruleset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::GameLift::MatchmakingRuleSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-gamelift-matchmakingruleset.html",
         "type" : "string",
         "enum" : [ "AWS::GameLift::MatchmakingRuleSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -16558,9 +19430,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-gamelift-script.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::GameLift::Script",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-gamelift-script.html",
         "type" : "string",
         "enum" : [ "AWS::GameLift::Script" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -16594,9 +19476,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-globalaccelerator-accelerator.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::GlobalAccelerator::Accelerator",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-globalaccelerator-accelerator.html",
         "type" : "string",
         "enum" : [ "AWS::GlobalAccelerator::Accelerator" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -16648,9 +19540,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-globalaccelerator-endpointgroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::GlobalAccelerator::EndpointGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-globalaccelerator-endpointgroup.html",
         "type" : "string",
         "enum" : [ "AWS::GlobalAccelerator::EndpointGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -16714,9 +19616,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-globalaccelerator-listener.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::GlobalAccelerator::Listener",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-globalaccelerator-listener.html",
         "type" : "string",
         "enum" : [ "AWS::GlobalAccelerator::Listener" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -16760,9 +19672,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-classifier.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Glue::Classifier",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-classifier.html",
         "type" : "string",
         "enum" : [ "AWS::Glue::Classifier" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -16797,9 +19719,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-connection.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Glue::Connection",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-connection.html",
         "type" : "string",
         "enum" : [ "AWS::Glue::Connection" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -16830,9 +19762,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-crawler.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Glue::Crawler",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-crawler.html",
         "type" : "string",
         "enum" : [ "AWS::Glue::Crawler" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -16905,9 +19847,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-datacatalogencryptionsettings.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Glue::DataCatalogEncryptionSettings",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-datacatalogencryptionsettings.html",
         "type" : "string",
         "enum" : [ "AWS::Glue::DataCatalogEncryptionSettings" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -16938,9 +19890,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-database.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Glue::Database",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-database.html",
         "type" : "string",
         "enum" : [ "AWS::Glue::Database" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -16971,9 +19933,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-devendpoint.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Glue::DevEndpoint",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-devendpoint.html",
         "type" : "string",
         "enum" : [ "AWS::Glue::DevEndpoint" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17065,9 +20037,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-job.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Glue::Job",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-job.html",
         "type" : "string",
         "enum" : [ "AWS::Glue::Job" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17159,9 +20141,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-mltransform.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Glue::MLTransform",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-mltransform.html",
         "type" : "string",
         "enum" : [ "AWS::Glue::MLTransform" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17231,9 +20223,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-partition.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Glue::Partition",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-partition.html",
         "type" : "string",
         "enum" : [ "AWS::Glue::Partition" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17272,9 +20274,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-securityconfiguration.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Glue::SecurityConfiguration",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-securityconfiguration.html",
         "type" : "string",
         "enum" : [ "AWS::Glue::SecurityConfiguration" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17305,9 +20317,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-table.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Glue::Table",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-table.html",
         "type" : "string",
         "enum" : [ "AWS::Glue::Table" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17342,9 +20364,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-trigger.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Glue::Trigger",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-trigger.html",
         "type" : "string",
         "enum" : [ "AWS::Glue::Trigger" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17407,9 +20439,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-workflow.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Glue::Workflow",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-workflow.html",
         "type" : "string",
         "enum" : [ "AWS::Glue::Workflow" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17448,9 +20490,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-connectordefinition.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Greengrass::ConnectorDefinition",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-connectordefinition.html",
         "type" : "string",
         "enum" : [ "AWS::Greengrass::ConnectorDefinition" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17485,9 +20537,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-connectordefinitionversion.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Greengrass::ConnectorDefinitionVersion",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-connectordefinitionversion.html",
         "type" : "string",
         "enum" : [ "AWS::Greengrass::ConnectorDefinitionVersion" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17523,9 +20585,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-coredefinition.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Greengrass::CoreDefinition",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-coredefinition.html",
         "type" : "string",
         "enum" : [ "AWS::Greengrass::CoreDefinition" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17560,9 +20632,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-coredefinitionversion.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Greengrass::CoreDefinitionVersion",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-coredefinitionversion.html",
         "type" : "string",
         "enum" : [ "AWS::Greengrass::CoreDefinitionVersion" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17598,9 +20680,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-devicedefinition.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Greengrass::DeviceDefinition",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-devicedefinition.html",
         "type" : "string",
         "enum" : [ "AWS::Greengrass::DeviceDefinition" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17635,9 +20727,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-devicedefinitionversion.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Greengrass::DeviceDefinitionVersion",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-devicedefinitionversion.html",
         "type" : "string",
         "enum" : [ "AWS::Greengrass::DeviceDefinitionVersion" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17673,9 +20775,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-functiondefinition.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Greengrass::FunctionDefinition",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-functiondefinition.html",
         "type" : "string",
         "enum" : [ "AWS::Greengrass::FunctionDefinition" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17710,9 +20822,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-functiondefinitionversion.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Greengrass::FunctionDefinitionVersion",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-functiondefinitionversion.html",
         "type" : "string",
         "enum" : [ "AWS::Greengrass::FunctionDefinitionVersion" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17751,9 +20873,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-group.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Greengrass::Group",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-group.html",
         "type" : "string",
         "enum" : [ "AWS::Greengrass::Group" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17792,9 +20924,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-groupversion.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Greengrass::GroupVersion",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-groupversion.html",
         "type" : "string",
         "enum" : [ "AWS::Greengrass::GroupVersion" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17850,9 +20992,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-loggerdefinition.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Greengrass::LoggerDefinition",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-loggerdefinition.html",
         "type" : "string",
         "enum" : [ "AWS::Greengrass::LoggerDefinition" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17887,9 +21039,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-loggerdefinitionversion.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Greengrass::LoggerDefinitionVersion",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-loggerdefinitionversion.html",
         "type" : "string",
         "enum" : [ "AWS::Greengrass::LoggerDefinitionVersion" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17925,9 +21087,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-resourcedefinition.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Greengrass::ResourceDefinition",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-resourcedefinition.html",
         "type" : "string",
         "enum" : [ "AWS::Greengrass::ResourceDefinition" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -17962,9 +21134,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-resourcedefinitionversion.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Greengrass::ResourceDefinitionVersion",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-resourcedefinitionversion.html",
         "type" : "string",
         "enum" : [ "AWS::Greengrass::ResourceDefinitionVersion" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18000,9 +21182,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-subscriptiondefinition.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Greengrass::SubscriptionDefinition",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-subscriptiondefinition.html",
         "type" : "string",
         "enum" : [ "AWS::Greengrass::SubscriptionDefinition" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18037,9 +21229,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-subscriptiondefinitionversion.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Greengrass::SubscriptionDefinitionVersion",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrass-subscriptiondefinitionversion.html",
         "type" : "string",
         "enum" : [ "AWS::Greengrass::SubscriptionDefinitionVersion" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18075,9 +21277,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::GuardDuty::Detector",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html",
         "type" : "string",
         "enum" : [ "AWS::GuardDuty::Detector" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18112,9 +21324,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::GuardDuty::Filter",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html",
         "type" : "string",
         "enum" : [ "AWS::GuardDuty::Filter" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18161,9 +21383,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::GuardDuty::IPSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html",
         "type" : "string",
         "enum" : [ "AWS::GuardDuty::IPSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18207,9 +21439,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-master.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::GuardDuty::Master",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-master.html",
         "type" : "string",
         "enum" : [ "AWS::GuardDuty::Master" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18245,9 +21487,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-member.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::GuardDuty::Member",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-member.html",
         "type" : "string",
         "enum" : [ "AWS::GuardDuty::Member" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18295,9 +21547,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::GuardDuty::ThreatIntelSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html",
         "type" : "string",
         "enum" : [ "AWS::GuardDuty::ThreatIntelSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18341,9 +21603,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IAM::AccessKey",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html",
         "type" : "string",
         "enum" : [ "AWS::IAM::AccessKey" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18379,9 +21651,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-group.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IAM::Group",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-group.html",
         "type" : "string",
         "enum" : [ "AWS::IAM::Group" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18430,9 +21712,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IAM::InstanceProfile",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html",
         "type" : "string",
         "enum" : [ "AWS::IAM::InstanceProfile" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18472,9 +21764,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IAM::ManagedPolicy",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html",
         "type" : "string",
         "enum" : [ "AWS::IAM::ManagedPolicy" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18539,9 +21841,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IAM::Policy",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html",
         "type" : "string",
         "enum" : [ "AWS::IAM::Policy" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18597,9 +21909,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IAM::Role",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html",
         "type" : "string",
         "enum" : [ "AWS::IAM::Role" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18672,9 +21994,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-servicelinkedrole.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IAM::ServiceLinkedRole",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-servicelinkedrole.html",
         "type" : "string",
         "enum" : [ "AWS::IAM::ServiceLinkedRole" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18710,9 +22042,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IAM::User",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html",
         "type" : "string",
         "enum" : [ "AWS::IAM::User" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18783,9 +22125,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-addusertogroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IAM::UserToGroupAddition",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-addusertogroup.html",
         "type" : "string",
         "enum" : [ "AWS::IAM::UserToGroupAddition" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18821,9 +22173,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-component.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ImageBuilder::Component",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-component.html",
         "type" : "string",
         "enum" : [ "AWS::ImageBuilder::Component" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18896,9 +22258,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-distributionconfiguration.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ImageBuilder::DistributionConfiguration",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-distributionconfiguration.html",
         "type" : "string",
         "enum" : [ "AWS::ImageBuilder::DistributionConfiguration" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -18947,9 +22319,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-image.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ImageBuilder::Image",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-image.html",
         "type" : "string",
         "enum" : [ "AWS::ImageBuilder::Image" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19001,9 +22383,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagepipeline.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ImageBuilder::ImagePipeline",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagepipeline.html",
         "type" : "string",
         "enum" : [ "AWS::ImageBuilder::ImagePipeline" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19070,9 +22462,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagerecipe.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ImageBuilder::ImageRecipe",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagerecipe.html",
         "type" : "string",
         "enum" : [ "AWS::ImageBuilder::ImageRecipe" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19141,9 +22543,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ImageBuilder::InfrastructureConfiguration",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html",
         "type" : "string",
         "enum" : [ "AWS::ImageBuilder::InfrastructureConfiguration" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19233,9 +22645,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-inspector-assessmenttarget.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Inspector::AssessmentTarget",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-inspector-assessmenttarget.html",
         "type" : "string",
         "enum" : [ "AWS::Inspector::AssessmentTarget" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19266,9 +22688,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-inspector-assessmenttemplate.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Inspector::AssessmentTemplate",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-inspector-assessmenttemplate.html",
         "type" : "string",
         "enum" : [ "AWS::Inspector::AssessmentTemplate" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19320,9 +22752,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-inspector-resourcegroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Inspector::ResourceGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-inspector-resourcegroup.html",
         "type" : "string",
         "enum" : [ "AWS::Inspector::ResourceGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19354,9 +22796,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot1click-device.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IoT1Click::Device",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot1click-device.html",
         "type" : "string",
         "enum" : [ "AWS::IoT1Click::Device" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19388,9 +22840,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot1click-placement.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IoT1Click::Placement",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot1click-placement.html",
         "type" : "string",
         "enum" : [ "AWS::IoT1Click::Placement" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19430,9 +22892,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot1click-project.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IoT1Click::Project",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot1click-project.html",
         "type" : "string",
         "enum" : [ "AWS::IoT1Click::Project" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19466,9 +22938,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-authorizer.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IoT::Authorizer",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-authorizer.html",
         "type" : "string",
         "enum" : [ "AWS::IoT::Authorizer" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19518,9 +23000,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-certificate.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IoT::Certificate",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-certificate.html",
         "type" : "string",
         "enum" : [ "AWS::IoT::Certificate" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19564,9 +23056,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-policy.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IoT::Policy",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-policy.html",
         "type" : "string",
         "enum" : [ "AWS::IoT::Policy" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19598,9 +23100,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-policyprincipalattachment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IoT::PolicyPrincipalAttachment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-policyprincipalattachment.html",
         "type" : "string",
         "enum" : [ "AWS::IoT::PolicyPrincipalAttachment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19632,9 +23144,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-provisioningtemplate.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IoT::ProvisioningTemplate",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-provisioningtemplate.html",
         "type" : "string",
         "enum" : [ "AWS::IoT::ProvisioningTemplate" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19684,9 +23206,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-thing.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IoT::Thing",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-thing.html",
         "type" : "string",
         "enum" : [ "AWS::IoT::Thing" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19716,9 +23248,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-thingprincipalattachment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IoT::ThingPrincipalAttachment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-thingprincipalattachment.html",
         "type" : "string",
         "enum" : [ "AWS::IoT::ThingPrincipalAttachment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19750,9 +23292,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-topicrule.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IoT::TopicRule",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-topicrule.html",
         "type" : "string",
         "enum" : [ "AWS::IoT::TopicRule" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19782,9 +23334,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotanalytics-channel.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IoTAnalytics::Channel",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotanalytics-channel.html",
         "type" : "string",
         "enum" : [ "AWS::IoTAnalytics::Channel" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19825,9 +23387,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotanalytics-dataset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IoTAnalytics::Dataset",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotanalytics-dataset.html",
         "type" : "string",
         "enum" : [ "AWS::IoTAnalytics::Dataset" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19893,9 +23465,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotanalytics-datastore.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IoTAnalytics::Datastore",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotanalytics-datastore.html",
         "type" : "string",
         "enum" : [ "AWS::IoTAnalytics::Datastore" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19936,9 +23518,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotanalytics-pipeline.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IoTAnalytics::Pipeline",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotanalytics-pipeline.html",
         "type" : "string",
         "enum" : [ "AWS::IoTAnalytics::Pipeline" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -19982,9 +23574,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotevents-detectormodel.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IoTEvents::DetectorModel",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotevents-detectormodel.html",
         "type" : "string",
         "enum" : [ "AWS::IoTEvents::DetectorModel" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20038,9 +23640,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotevents-input.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IoTEvents::Input",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotevents-input.html",
         "type" : "string",
         "enum" : [ "AWS::IoTEvents::Input" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20082,9 +23694,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotthingsgraph-flowtemplate.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::IoTThingsGraph::FlowTemplate",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotthingsgraph-flowtemplate.html",
         "type" : "string",
         "enum" : [ "AWS::IoTThingsGraph::FlowTemplate" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20114,9 +23736,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kms-alias.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::KMS::Alias",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kms-alias.html",
         "type" : "string",
         "enum" : [ "AWS::KMS::Alias" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20148,9 +23780,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kms-key.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::KMS::Key",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kms-key.html",
         "type" : "string",
         "enum" : [ "AWS::KMS::Key" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20212,9 +23854,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kendra-datasource.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Kendra::DataSource",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kendra-datasource.html",
         "type" : "string",
         "enum" : [ "AWS::Kendra::DataSource" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20268,9 +23920,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kendra-faq.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Kendra::Faq",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kendra-faq.html",
         "type" : "string",
         "enum" : [ "AWS::Kendra::Faq" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20316,9 +23978,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kendra-index.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Kendra::Index",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kendra-index.html",
         "type" : "string",
         "enum" : [ "AWS::Kendra::Index" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20370,9 +24042,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesis-stream.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Kinesis::Stream",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesis-stream.html",
         "type" : "string",
         "enum" : [ "AWS::Kinesis::Stream" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20419,9 +24101,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesis-streamconsumer.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Kinesis::StreamConsumer",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesis-streamconsumer.html",
         "type" : "string",
         "enum" : [ "AWS::Kinesis::StreamConsumer" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20453,9 +24145,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalytics-application.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::KinesisAnalytics::Application",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalytics-application.html",
         "type" : "string",
         "enum" : [ "AWS::KinesisAnalytics::Application" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20499,9 +24201,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalytics-applicationoutput.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::KinesisAnalytics::ApplicationOutput",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalytics-applicationoutput.html",
         "type" : "string",
         "enum" : [ "AWS::KinesisAnalytics::ApplicationOutput" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20532,9 +24244,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalytics-applicationreferencedatasource.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::KinesisAnalytics::ApplicationReferenceDataSource",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalytics-applicationreferencedatasource.html",
         "type" : "string",
         "enum" : [ "AWS::KinesisAnalytics::ApplicationReferenceDataSource" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20565,9 +24287,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::KinesisAnalyticsV2::Application",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html",
         "type" : "string",
         "enum" : [ "AWS::KinesisAnalyticsV2::Application" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20618,9 +24350,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-applicationcloudwatchloggingoption.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::KinesisAnalyticsV2::ApplicationCloudWatchLoggingOption",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-applicationcloudwatchloggingoption.html",
         "type" : "string",
         "enum" : [ "AWS::KinesisAnalyticsV2::ApplicationCloudWatchLoggingOption" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20651,9 +24393,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-applicationoutput.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::KinesisAnalyticsV2::ApplicationOutput",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-applicationoutput.html",
         "type" : "string",
         "enum" : [ "AWS::KinesisAnalyticsV2::ApplicationOutput" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20684,9 +24436,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-applicationreferencedatasource.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::KinesisAnalyticsV2::ApplicationReferenceDataSource",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-applicationreferencedatasource.html",
         "type" : "string",
         "enum" : [ "AWS::KinesisAnalyticsV2::ApplicationReferenceDataSource" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20717,9 +24479,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisfirehose-deliverystream.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::KinesisFirehose::DeliveryStream",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisfirehose-deliverystream.html",
         "type" : "string",
         "enum" : [ "AWS::KinesisFirehose::DeliveryStream" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20771,9 +24543,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lakeformation-datalakesettings.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::LakeFormation::DataLakeSettings",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lakeformation-datalakesettings.html",
         "type" : "string",
         "enum" : [ "AWS::LakeFormation::DataLakeSettings" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20799,9 +24581,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lakeformation-permissions.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::LakeFormation::Permissions",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lakeformation-permissions.html",
         "type" : "string",
         "enum" : [ "AWS::LakeFormation::Permissions" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20846,9 +24638,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lakeformation-resource.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::LakeFormation::Resource",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lakeformation-resource.html",
         "type" : "string",
         "enum" : [ "AWS::LakeFormation::Resource" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20884,9 +24686,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-alias.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Lambda::Alias",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-alias.html",
         "type" : "string",
         "enum" : [ "AWS::Lambda::Alias" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20932,9 +24744,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventinvokeconfig.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Lambda::EventInvokeConfig",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventinvokeconfig.html",
         "type" : "string",
         "enum" : [ "AWS::Lambda::EventInvokeConfig" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -20977,9 +24799,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Lambda::EventSourceMapping",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html",
         "type" : "string",
         "enum" : [ "AWS::Lambda::EventSourceMapping" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21055,9 +24887,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Lambda::Function",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html",
         "type" : "string",
         "enum" : [ "AWS::Lambda::Function" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21158,9 +25000,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-layerversion.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Lambda::LayerVersion",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-layerversion.html",
         "type" : "string",
         "enum" : [ "AWS::Lambda::LayerVersion" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21206,9 +25058,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-layerversionpermission.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Lambda::LayerVersionPermission",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-layerversionpermission.html",
         "type" : "string",
         "enum" : [ "AWS::Lambda::LayerVersionPermission" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21248,9 +25110,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-permission.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Lambda::Permission",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-permission.html",
         "type" : "string",
         "enum" : [ "AWS::Lambda::Permission" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21298,9 +25170,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-version.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Lambda::Version",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-version.html",
         "type" : "string",
         "enum" : [ "AWS::Lambda::Version" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21339,9 +25221,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-destination.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Logs::Destination",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-destination.html",
         "type" : "string",
         "enum" : [ "AWS::Logs::Destination" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21381,9 +25273,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Logs::LogGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html",
         "type" : "string",
         "enum" : [ "AWS::Logs::LogGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21414,9 +25316,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-logstream.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Logs::LogStream",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-logstream.html",
         "type" : "string",
         "enum" : [ "AWS::Logs::LogStream" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21448,9 +25360,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-metricfilter.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Logs::MetricFilter",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-metricfilter.html",
         "type" : "string",
         "enum" : [ "AWS::Logs::MetricFilter" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21491,9 +25413,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-subscriptionfilter.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Logs::SubscriptionFilter",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-subscriptionfilter.html",
         "type" : "string",
         "enum" : [ "AWS::Logs::SubscriptionFilter" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21533,9 +25465,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-msk-cluster.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::MSK::Cluster",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-msk-cluster.html",
         "type" : "string",
         "enum" : [ "AWS::MSK::Cluster" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21597,9 +25539,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-macie-customdataidentifier.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Macie::CustomDataIdentifier",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-macie-customdataidentifier.html",
         "type" : "string",
         "enum" : [ "AWS::Macie::CustomDataIdentifier" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21655,9 +25607,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-macie-findingsfilter.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Macie::FindingsFilter",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-macie-findingsfilter.html",
         "type" : "string",
         "enum" : [ "AWS::Macie::FindingsFilter" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21700,9 +25662,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-macie-session.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Macie::Session",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-macie-session.html",
         "type" : "string",
         "enum" : [ "AWS::Macie::Session" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21733,9 +25705,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-managedblockchain-member.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ManagedBlockchain::Member",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-managedblockchain-member.html",
         "type" : "string",
         "enum" : [ "AWS::ManagedBlockchain::Member" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21772,9 +25754,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-managedblockchain-node.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ManagedBlockchain::Node",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-managedblockchain-node.html",
         "type" : "string",
         "enum" : [ "AWS::ManagedBlockchain::Node" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21809,9 +25801,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mediaconvert-jobtemplate.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::MediaConvert::JobTemplate",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mediaconvert-jobtemplate.html",
         "type" : "string",
         "enum" : [ "AWS::MediaConvert::JobTemplate" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21878,9 +25880,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mediaconvert-preset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::MediaConvert::Preset",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mediaconvert-preset.html",
         "type" : "string",
         "enum" : [ "AWS::MediaConvert::Preset" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21924,9 +25936,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mediaconvert-queue.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::MediaConvert::Queue",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mediaconvert-queue.html",
         "type" : "string",
         "enum" : [ "AWS::MediaConvert::Queue" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -21969,9 +25991,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-medialive-channel.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::MediaLive::Channel",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-medialive-channel.html",
         "type" : "string",
         "enum" : [ "AWS::MediaLive::Channel" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -22036,9 +26068,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-medialive-input.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::MediaLive::Input",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-medialive-input.html",
         "type" : "string",
         "enum" : [ "AWS::MediaLive::Input" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -22120,9 +26162,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-medialive-inputsecuritygroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::MediaLive::InputSecurityGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-medialive-inputsecuritygroup.html",
         "type" : "string",
         "enum" : [ "AWS::MediaLive::InputSecurityGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -22157,9 +26209,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mediastore-container.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::MediaStore::Container",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mediastore-container.html",
         "type" : "string",
         "enum" : [ "AWS::MediaStore::Container" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -22218,9 +26280,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-neptune-dbcluster.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Neptune::DBCluster",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-neptune-dbcluster.html",
         "type" : "string",
         "enum" : [ "AWS::Neptune::DBCluster" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -22351,9 +26423,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-neptune-dbclusterparametergroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Neptune::DBClusterParameterGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-neptune-dbclusterparametergroup.html",
         "type" : "string",
         "enum" : [ "AWS::Neptune::DBClusterParameterGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -22401,9 +26483,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-neptune-dbinstance.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Neptune::DBInstance",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-neptune-dbinstance.html",
         "type" : "string",
         "enum" : [ "AWS::Neptune::DBInstance" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -22475,9 +26567,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-neptune-dbparametergroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Neptune::DBParameterGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-neptune-dbparametergroup.html",
         "type" : "string",
         "enum" : [ "AWS::Neptune::DBParameterGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -22525,9 +26627,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-neptune-dbsubnetgroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Neptune::DBSubnetGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-neptune-dbsubnetgroup.html",
         "type" : "string",
         "enum" : [ "AWS::Neptune::DBSubnetGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -22575,9 +26687,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-customergatewayassociation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::NetworkManager::CustomerGatewayAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-customergatewayassociation.html",
         "type" : "string",
         "enum" : [ "AWS::NetworkManager::CustomerGatewayAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -22617,9 +26739,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-device.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::NetworkManager::Device",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-device.html",
         "type" : "string",
         "enum" : [ "AWS::NetworkManager::Device" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -22682,9 +26814,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-globalnetwork.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::NetworkManager::GlobalNetwork",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-globalnetwork.html",
         "type" : "string",
         "enum" : [ "AWS::NetworkManager::GlobalNetwork" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -22719,9 +26861,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-link.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::NetworkManager::Link",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-link.html",
         "type" : "string",
         "enum" : [ "AWS::NetworkManager::Link" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -22776,9 +26928,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-linkassociation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::NetworkManager::LinkAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-linkassociation.html",
         "type" : "string",
         "enum" : [ "AWS::NetworkManager::LinkAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -22814,9 +26976,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-site.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::NetworkManager::Site",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-site.html",
         "type" : "string",
         "enum" : [ "AWS::NetworkManager::Site" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -22859,9 +27031,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-transitgatewayregistration.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::NetworkManager::TransitGatewayRegistration",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkmanager-transitgatewayregistration.html",
         "type" : "string",
         "enum" : [ "AWS::NetworkManager::TransitGatewayRegistration" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -22893,9 +27075,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-app.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::OpsWorks::App",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-app.html",
         "type" : "string",
         "enum" : [ "AWS::OpsWorks::App" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -22983,9 +27175,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-elbattachment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::OpsWorks::ElasticLoadBalancerAttachment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-elbattachment.html",
         "type" : "string",
         "enum" : [ "AWS::OpsWorks::ElasticLoadBalancerAttachment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -23017,9 +27219,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-instance.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::OpsWorks::Instance",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-instance.html",
         "type" : "string",
         "enum" : [ "AWS::OpsWorks::Instance" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -23145,9 +27357,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-layer.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::OpsWorks::Layer",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-layer.html",
         "type" : "string",
         "enum" : [ "AWS::OpsWorks::Layer" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -23265,9 +27487,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-stack.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::OpsWorks::Stack",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-stack.html",
         "type" : "string",
         "enum" : [ "AWS::OpsWorks::Stack" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -23412,9 +27644,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-userprofile.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::OpsWorks::UserProfile",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-userprofile.html",
         "type" : "string",
         "enum" : [ "AWS::OpsWorks::UserProfile" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -23454,9 +27696,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-volume.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::OpsWorks::Volume",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-volume.html",
         "type" : "string",
         "enum" : [ "AWS::OpsWorks::Volume" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -23496,9 +27748,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworkscm-server.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::OpsWorksCM::Server",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworkscm-server.html",
         "type" : "string",
         "enum" : [ "AWS::OpsWorksCM::Server" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -23622,9 +27884,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-admchannel.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Pinpoint::ADMChannel",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-admchannel.html",
         "type" : "string",
         "enum" : [ "AWS::Pinpoint::ADMChannel" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -23664,9 +27936,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-apnschannel.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Pinpoint::APNSChannel",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-apnschannel.html",
         "type" : "string",
         "enum" : [ "AWS::Pinpoint::APNSChannel" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -23726,9 +28008,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-apnssandboxchannel.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Pinpoint::APNSSandboxChannel",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-apnssandboxchannel.html",
         "type" : "string",
         "enum" : [ "AWS::Pinpoint::APNSSandboxChannel" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -23788,9 +28080,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-apnsvoipchannel.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Pinpoint::APNSVoipChannel",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-apnsvoipchannel.html",
         "type" : "string",
         "enum" : [ "AWS::Pinpoint::APNSVoipChannel" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -23850,9 +28152,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-apnsvoipsandboxchannel.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Pinpoint::APNSVoipSandboxChannel",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-apnsvoipsandboxchannel.html",
         "type" : "string",
         "enum" : [ "AWS::Pinpoint::APNSVoipSandboxChannel" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -23912,9 +28224,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-app.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Pinpoint::App",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-app.html",
         "type" : "string",
         "enum" : [ "AWS::Pinpoint::App" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -23946,9 +28268,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-applicationsettings.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Pinpoint::ApplicationSettings",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-applicationsettings.html",
         "type" : "string",
         "enum" : [ "AWS::Pinpoint::ApplicationSettings" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -23989,9 +28321,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-baiduchannel.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Pinpoint::BaiduChannel",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-baiduchannel.html",
         "type" : "string",
         "enum" : [ "AWS::Pinpoint::BaiduChannel" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -24031,9 +28373,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-campaign.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Pinpoint::Campaign",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-campaign.html",
         "type" : "string",
         "enum" : [ "AWS::Pinpoint::Campaign" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -24117,9 +28469,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-emailchannel.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Pinpoint::EmailChannel",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-emailchannel.html",
         "type" : "string",
         "enum" : [ "AWS::Pinpoint::EmailChannel" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -24167,9 +28529,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-emailtemplate.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Pinpoint::EmailTemplate",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-emailtemplate.html",
         "type" : "string",
         "enum" : [ "AWS::Pinpoint::EmailTemplate" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -24221,9 +28593,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-eventstream.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Pinpoint::EventStream",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-eventstream.html",
         "type" : "string",
         "enum" : [ "AWS::Pinpoint::EventStream" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -24259,9 +28641,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-gcmchannel.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Pinpoint::GCMChannel",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-gcmchannel.html",
         "type" : "string",
         "enum" : [ "AWS::Pinpoint::GCMChannel" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -24297,9 +28689,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-pushtemplate.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Pinpoint::PushTemplate",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-pushtemplate.html",
         "type" : "string",
         "enum" : [ "AWS::Pinpoint::PushTemplate" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -24354,9 +28756,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-smschannel.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Pinpoint::SMSChannel",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-smschannel.html",
         "type" : "string",
         "enum" : [ "AWS::Pinpoint::SMSChannel" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -24396,9 +28808,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-segment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Pinpoint::Segment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-segment.html",
         "type" : "string",
         "enum" : [ "AWS::Pinpoint::Segment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -24440,9 +28862,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-smstemplate.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Pinpoint::SmsTemplate",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-smstemplate.html",
         "type" : "string",
         "enum" : [ "AWS::Pinpoint::SmsTemplate" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -24486,9 +28918,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-voicechannel.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Pinpoint::VoiceChannel",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpoint-voicechannel.html",
         "type" : "string",
         "enum" : [ "AWS::Pinpoint::VoiceChannel" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -24520,9 +28962,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpointemail-configurationset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::PinpointEmail::ConfigurationSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpointemail-configurationset.html",
         "type" : "string",
         "enum" : [ "AWS::PinpointEmail::ConfigurationSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -24570,9 +29022,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpointemail-configurationseteventdestination.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::PinpointEmail::ConfigurationSetEventDestination",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpointemail-configurationseteventdestination.html",
         "type" : "string",
         "enum" : [ "AWS::PinpointEmail::ConfigurationSetEventDestination" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -24607,9 +29069,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpointemail-dedicatedippool.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::PinpointEmail::DedicatedIpPool",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpointemail-dedicatedippool.html",
         "type" : "string",
         "enum" : [ "AWS::PinpointEmail::DedicatedIpPool" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -24644,9 +29116,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpointemail-identity.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::PinpointEmail::Identity",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pinpointemail-identity.html",
         "type" : "string",
         "enum" : [ "AWS::PinpointEmail::Identity" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -24693,9 +29175,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-qldb-ledger.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::QLDB::Ledger",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-qldb-ledger.html",
         "type" : "string",
         "enum" : [ "AWS::QLDB::Ledger" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -24739,9 +29231,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-qldb-stream.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::QLDB::Stream",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-qldb-stream.html",
         "type" : "string",
         "enum" : [ "AWS::QLDB::Stream" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -24797,9 +29299,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ram-resourceshare.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::RAM::ResourceShare",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ram-resourceshare.html",
         "type" : "string",
         "enum" : [ "AWS::RAM::ResourceShare" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -24855,9 +29367,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::RDS::DBCluster",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html",
         "type" : "string",
         "enum" : [ "AWS::RDS::DBCluster" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -25028,9 +29550,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbclusterparametergroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::RDS::DBClusterParameterGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbclusterparametergroup.html",
         "type" : "string",
         "enum" : [ "AWS::RDS::DBClusterParameterGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -25074,9 +29606,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::RDS::DBInstance",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html",
         "type" : "string",
         "enum" : [ "AWS::RDS::DBInstance" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -25335,9 +29877,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbparametergroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::RDS::DBParameterGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbparametergroup.html",
         "type" : "string",
         "enum" : [ "AWS::RDS::DBParameterGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -25386,9 +29938,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbproxy.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::RDS::DBProxy",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbproxy.html",
         "type" : "string",
         "enum" : [ "AWS::RDS::DBProxy" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -25468,9 +30030,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbproxytargetgroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::RDS::DBProxyTargetGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbproxytargetgroup.html",
         "type" : "string",
         "enum" : [ "AWS::RDS::DBProxyTargetGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -25521,9 +30093,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-security-group.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::RDS::DBSecurityGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-security-group.html",
         "type" : "string",
         "enum" : [ "AWS::RDS::DBSecurityGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -25572,9 +30154,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-security-group-ingress.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::RDS::DBSecurityGroupIngress",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-security-group-ingress.html",
         "type" : "string",
         "enum" : [ "AWS::RDS::DBSecurityGroupIngress" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -25618,9 +30210,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbsubnet-group.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::RDS::DBSubnetGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbsubnet-group.html",
         "type" : "string",
         "enum" : [ "AWS::RDS::DBSubnetGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -25669,9 +30271,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-eventsubscription.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::RDS::EventSubscription",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-eventsubscription.html",
         "type" : "string",
         "enum" : [ "AWS::RDS::EventSubscription" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -25724,9 +30336,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-optiongroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::RDS::OptionGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-optiongroup.html",
         "type" : "string",
         "enum" : [ "AWS::RDS::OptionGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -25778,9 +30400,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-cluster.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Redshift::Cluster",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-cluster.html",
         "type" : "string",
         "enum" : [ "AWS::Redshift::Cluster" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -25936,9 +30568,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-clusterparametergroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Redshift::ClusterParameterGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-clusterparametergroup.html",
         "type" : "string",
         "enum" : [ "AWS::Redshift::ClusterParameterGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -25986,9 +30628,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-clustersecuritygroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Redshift::ClusterSecurityGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-clustersecuritygroup.html",
         "type" : "string",
         "enum" : [ "AWS::Redshift::ClusterSecurityGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26024,9 +30676,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-clustersecuritygroupingress.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Redshift::ClusterSecurityGroupIngress",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-clustersecuritygroupingress.html",
         "type" : "string",
         "enum" : [ "AWS::Redshift::ClusterSecurityGroupIngress" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26066,9 +30728,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-clustersubnetgroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Redshift::ClusterSubnetGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-clustersubnetgroup.html",
         "type" : "string",
         "enum" : [ "AWS::Redshift::ClusterSubnetGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26112,9 +30784,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-resourcegroups-group.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ResourceGroups::Group",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-resourcegroups-group.html",
         "type" : "string",
         "enum" : [ "AWS::ResourceGroups::Group" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26157,9 +30839,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-robomaker-fleet.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::RoboMaker::Fleet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-robomaker-fleet.html",
         "type" : "string",
         "enum" : [ "AWS::RoboMaker::Fleet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26190,9 +30882,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-robomaker-robot.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::RoboMaker::Robot",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-robomaker-robot.html",
         "type" : "string",
         "enum" : [ "AWS::RoboMaker::Robot" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26236,9 +30938,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-robomaker-robotapplication.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::RoboMaker::RobotApplication",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-robomaker-robotapplication.html",
         "type" : "string",
         "enum" : [ "AWS::RoboMaker::RobotApplication" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26285,9 +30997,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-robomaker-robotapplicationversion.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::RoboMaker::RobotApplicationVersion",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-robomaker-robotapplicationversion.html",
         "type" : "string",
         "enum" : [ "AWS::RoboMaker::RobotApplicationVersion" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26319,9 +31041,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-robomaker-simulationapplication.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::RoboMaker::SimulationApplication",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-robomaker-simulationapplication.html",
         "type" : "string",
         "enum" : [ "AWS::RoboMaker::SimulationApplication" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26374,9 +31106,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-robomaker-simulationapplicationversion.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::RoboMaker::SimulationApplicationVersion",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-robomaker-simulationapplicationversion.html",
         "type" : "string",
         "enum" : [ "AWS::RoboMaker::SimulationApplicationVersion" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26408,9 +31150,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53-healthcheck.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Route53::HealthCheck",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53-healthcheck.html",
         "type" : "string",
         "enum" : [ "AWS::Route53::HealthCheck" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26447,9 +31199,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53-hostedzone.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Route53::HostedZone",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53-hostedzone.html",
         "type" : "string",
         "enum" : [ "AWS::Route53::HostedZone" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26501,9 +31263,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Route53::RecordSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html",
         "type" : "string",
         "enum" : [ "AWS::Route53::RecordSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26589,9 +31361,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53-recordsetgroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Route53::RecordSetGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53-recordsetgroup.html",
         "type" : "string",
         "enum" : [ "AWS::Route53::RecordSetGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26635,9 +31417,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverendpoint.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Route53Resolver::ResolverEndpoint",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverendpoint.html",
         "type" : "string",
         "enum" : [ "AWS::Route53Resolver::ResolverEndpoint" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26693,9 +31485,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverqueryloggingconfig.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Route53Resolver::ResolverQueryLoggingConfig",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverqueryloggingconfig.html",
         "type" : "string",
         "enum" : [ "AWS::Route53Resolver::ResolverQueryLoggingConfig" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26726,9 +31528,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverqueryloggingconfigassociation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Route53Resolver::ResolverQueryLoggingConfigAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverqueryloggingconfigassociation.html",
         "type" : "string",
         "enum" : [ "AWS::Route53Resolver::ResolverQueryLoggingConfigAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26759,9 +31571,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverrule.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Route53Resolver::ResolverRule",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverrule.html",
         "type" : "string",
         "enum" : [ "AWS::Route53Resolver::ResolverRule" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26817,9 +31639,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverruleassociation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Route53Resolver::ResolverRuleAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverruleassociation.html",
         "type" : "string",
         "enum" : [ "AWS::Route53Resolver::ResolverRuleAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26855,9 +31687,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-s3-accesspoint.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::S3::AccessPoint",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-s3-accesspoint.html",
         "type" : "string",
         "enum" : [ "AWS::S3::AccessPoint" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -26911,9 +31753,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::S3::Bucket",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html",
         "type" : "string",
         "enum" : [ "AWS::S3::Bucket" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27016,9 +31868,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-policy.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::S3::BucketPolicy",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-policy.html",
         "type" : "string",
         "enum" : [ "AWS::S3::BucketPolicy" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27050,9 +31912,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-simpledb.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SDB::Domain",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-simpledb.html",
         "type" : "string",
         "enum" : [ "AWS::SDB::Domain" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27079,9 +31951,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ses-configurationset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SES::ConfigurationSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ses-configurationset.html",
         "type" : "string",
         "enum" : [ "AWS::SES::ConfigurationSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27108,9 +31990,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ses-configurationseteventdestination.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SES::ConfigurationSetEventDestination",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ses-configurationseteventdestination.html",
         "type" : "string",
         "enum" : [ "AWS::SES::ConfigurationSetEventDestination" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27141,9 +32033,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ses-receiptfilter.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SES::ReceiptFilter",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ses-receiptfilter.html",
         "type" : "string",
         "enum" : [ "AWS::SES::ReceiptFilter" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27169,9 +32071,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ses-receiptrule.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SES::ReceiptRule",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ses-receiptrule.html",
         "type" : "string",
         "enum" : [ "AWS::SES::ReceiptRule" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27206,9 +32118,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ses-receiptruleset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SES::ReceiptRuleSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ses-receiptruleset.html",
         "type" : "string",
         "enum" : [ "AWS::SES::ReceiptRuleSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27235,9 +32157,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ses-template.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SES::Template",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ses-template.html",
         "type" : "string",
         "enum" : [ "AWS::SES::Template" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27263,9 +32195,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SNS::Subscription",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html",
         "type" : "string",
         "enum" : [ "AWS::SNS::Subscription" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27321,9 +32263,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-topic.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SNS::Topic",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-topic.html",
         "type" : "string",
         "enum" : [ "AWS::SNS::Topic" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27378,9 +32330,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-policy.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SNS::TopicPolicy",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-policy.html",
         "type" : "string",
         "enum" : [ "AWS::SNS::TopicPolicy" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27416,9 +32378,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SQS::Queue",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html",
         "type" : "string",
         "enum" : [ "AWS::SQS::Queue" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27493,9 +32465,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-policy.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SQS::QueuePolicy",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-policy.html",
         "type" : "string",
         "enum" : [ "AWS::SQS::QueuePolicy" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27531,9 +32513,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-association.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SSM::Association",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-association.html",
         "type" : "string",
         "enum" : [ "AWS::SSM::Association" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27625,9 +32617,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-document.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SSM::Document",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-document.html",
         "type" : "string",
         "enum" : [ "AWS::SSM::Document" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27671,9 +32673,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindow.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SSM::MaintenanceWindow",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindow.html",
         "type" : "string",
         "enum" : [ "AWS::SSM::MaintenanceWindow" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27745,9 +32757,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SSM::MaintenanceWindowTarget",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html",
         "type" : "string",
         "enum" : [ "AWS::SSM::MaintenanceWindowTarget" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27799,9 +32821,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtask.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SSM::MaintenanceWindowTask",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtask.html",
         "type" : "string",
         "enum" : [ "AWS::SSM::MaintenanceWindowTask" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27879,9 +32911,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-parameter.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SSM::Parameter",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-parameter.html",
         "type" : "string",
         "enum" : [ "AWS::SSM::Parameter" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -27941,9 +32983,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-patchbaseline.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SSM::PatchBaseline",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-patchbaseline.html",
         "type" : "string",
         "enum" : [ "AWS::SSM::PatchBaseline" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -28037,9 +33089,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-resourcedatasync.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SSM::ResourceDataSync",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-resourcedatasync.html",
         "type" : "string",
         "enum" : [ "AWS::SSM::ResourceDataSync" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -28097,9 +33159,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sso-assignment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SSO::Assignment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sso-assignment.html",
         "type" : "string",
         "enum" : [ "AWS::SSO::Assignment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -28147,9 +33219,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sso-permissionset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SSO::PermissionSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sso-permissionset.html",
         "type" : "string",
         "enum" : [ "AWS::SSO::PermissionSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -28213,9 +33295,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-coderepository.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SageMaker::CodeRepository",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-coderepository.html",
         "type" : "string",
         "enum" : [ "AWS::SageMaker::CodeRepository" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -28245,9 +33337,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-endpoint.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SageMaker::Endpoint",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-endpoint.html",
         "type" : "string",
         "enum" : [ "AWS::SageMaker::Endpoint" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -28299,9 +33401,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-endpointconfig.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SageMaker::EndpointConfig",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-endpointconfig.html",
         "type" : "string",
         "enum" : [ "AWS::SageMaker::EndpointConfig" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -28352,9 +33464,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-model.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SageMaker::Model",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-model.html",
         "type" : "string",
         "enum" : [ "AWS::SageMaker::Model" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -28412,9 +33534,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-monitoringschedule.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SageMaker::MonitoringSchedule",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-monitoringschedule.html",
         "type" : "string",
         "enum" : [ "AWS::SageMaker::MonitoringSchedule" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -28480,9 +33612,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-notebookinstance.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SageMaker::NotebookInstance",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-notebookinstance.html",
         "type" : "string",
         "enum" : [ "AWS::SageMaker::NotebookInstance" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -28578,9 +33720,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-notebookinstancelifecycleconfig.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SageMaker::NotebookInstanceLifecycleConfig",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-notebookinstancelifecycleconfig.html",
         "type" : "string",
         "enum" : [ "AWS::SageMaker::NotebookInstanceLifecycleConfig" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -28623,9 +33775,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-workteam.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SageMaker::Workteam",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-workteam.html",
         "type" : "string",
         "enum" : [ "AWS::SageMaker::Workteam" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -28675,9 +33837,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-resourcepolicy.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SecretsManager::ResourcePolicy",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-resourcepolicy.html",
         "type" : "string",
         "enum" : [ "AWS::SecretsManager::ResourcePolicy" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -28709,9 +33881,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-rotationschedule.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SecretsManager::RotationSchedule",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-rotationschedule.html",
         "type" : "string",
         "enum" : [ "AWS::SecretsManager::RotationSchedule" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -28749,9 +33931,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-secret.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SecretsManager::Secret",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-secret.html",
         "type" : "string",
         "enum" : [ "AWS::SecretsManager::Secret" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -28801,9 +33993,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-secrettargetattachment.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SecretsManager::SecretTargetAttachment",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-secrettargetattachment.html",
         "type" : "string",
         "enum" : [ "AWS::SecretsManager::SecretTargetAttachment" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -28839,9 +34041,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-securityhub-hub.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::SecurityHub::Hub",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-securityhub-hub.html",
         "type" : "string",
         "enum" : [ "AWS::SecurityHub::Hub" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -28868,9 +34080,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-acceptedportfolioshare.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ServiceCatalog::AcceptedPortfolioShare",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-acceptedportfolioshare.html",
         "type" : "string",
         "enum" : [ "AWS::ServiceCatalog::AcceptedPortfolioShare" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -28902,9 +34124,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-cloudformationproduct.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ServiceCatalog::CloudFormationProduct",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-cloudformationproduct.html",
         "type" : "string",
         "enum" : [ "AWS::ServiceCatalog::CloudFormationProduct" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -28980,9 +34212,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-cloudformationprovisionedproduct.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ServiceCatalog::CloudFormationProvisionedProduct",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-cloudformationprovisionedproduct.html",
         "type" : "string",
         "enum" : [ "AWS::ServiceCatalog::CloudFormationProvisionedProduct" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -29065,9 +34307,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-launchnotificationconstraint.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ServiceCatalog::LaunchNotificationConstraint",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-launchnotificationconstraint.html",
         "type" : "string",
         "enum" : [ "AWS::ServiceCatalog::LaunchNotificationConstraint" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -29115,9 +34367,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-launchroleconstraint.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ServiceCatalog::LaunchRoleConstraint",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-launchroleconstraint.html",
         "type" : "string",
         "enum" : [ "AWS::ServiceCatalog::LaunchRoleConstraint" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -29165,9 +34427,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-launchtemplateconstraint.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ServiceCatalog::LaunchTemplateConstraint",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-launchtemplateconstraint.html",
         "type" : "string",
         "enum" : [ "AWS::ServiceCatalog::LaunchTemplateConstraint" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -29211,9 +34483,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-portfolio.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ServiceCatalog::Portfolio",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-portfolio.html",
         "type" : "string",
         "enum" : [ "AWS::ServiceCatalog::Portfolio" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -29261,9 +34543,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-portfolioprincipalassociation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ServiceCatalog::PortfolioPrincipalAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-portfolioprincipalassociation.html",
         "type" : "string",
         "enum" : [ "AWS::ServiceCatalog::PortfolioPrincipalAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -29303,9 +34595,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-portfolioproductassociation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ServiceCatalog::PortfolioProductAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-portfolioproductassociation.html",
         "type" : "string",
         "enum" : [ "AWS::ServiceCatalog::PortfolioProductAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -29345,9 +34647,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-portfolioshare.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ServiceCatalog::PortfolioShare",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-portfolioshare.html",
         "type" : "string",
         "enum" : [ "AWS::ServiceCatalog::PortfolioShare" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -29383,9 +34695,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-resourceupdateconstraint.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ServiceCatalog::ResourceUpdateConstraint",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-resourceupdateconstraint.html",
         "type" : "string",
         "enum" : [ "AWS::ServiceCatalog::ResourceUpdateConstraint" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -29429,9 +34751,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-stacksetconstraint.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ServiceCatalog::StackSetConstraint",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-stacksetconstraint.html",
         "type" : "string",
         "enum" : [ "AWS::ServiceCatalog::StackSetConstraint" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -29499,9 +34831,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-tagoption.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ServiceCatalog::TagOption",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-tagoption.html",
         "type" : "string",
         "enum" : [ "AWS::ServiceCatalog::TagOption" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -29537,9 +34879,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-tagoptionassociation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ServiceCatalog::TagOptionAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-tagoptionassociation.html",
         "type" : "string",
         "enum" : [ "AWS::ServiceCatalog::TagOptionAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -29571,9 +34923,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicediscovery-httpnamespace.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ServiceDiscovery::HttpNamespace",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicediscovery-httpnamespace.html",
         "type" : "string",
         "enum" : [ "AWS::ServiceDiscovery::HttpNamespace" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -29613,9 +34975,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicediscovery-instance.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ServiceDiscovery::Instance",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicediscovery-instance.html",
         "type" : "string",
         "enum" : [ "AWS::ServiceDiscovery::Instance" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -29651,9 +35023,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicediscovery-privatednsnamespace.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ServiceDiscovery::PrivateDnsNamespace",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicediscovery-privatednsnamespace.html",
         "type" : "string",
         "enum" : [ "AWS::ServiceDiscovery::PrivateDnsNamespace" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -29697,9 +35079,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicediscovery-publicdnsnamespace.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ServiceDiscovery::PublicDnsNamespace",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicediscovery-publicdnsnamespace.html",
         "type" : "string",
         "enum" : [ "AWS::ServiceDiscovery::PublicDnsNamespace" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -29739,9 +35131,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicediscovery-service.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::ServiceDiscovery::Service",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicediscovery-service.html",
         "type" : "string",
         "enum" : [ "AWS::ServiceDiscovery::Service" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -29793,13 +35195,27 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-activity.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::StepFunctions::Activity",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-activity.html",
         "type" : "string",
         "enum" : [ "AWS::StepFunctions::Activity" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
         "properties" : {
+          "Arn" : {
+            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-activity.html#cfn-stepfunctions-activity-arn",
+            "type" : [ "string", "object" ]
+          },
           "Tags" : {
             "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-activity.html#cfn-stepfunctions-activity-tags",
             "type" : "array",
@@ -29807,13 +35223,8 @@
               "$ref" : "#/definitions/AWS_StepFunctions_Activity_TagsEntry"
             },
             "minItems" : 0
-          },
-          "Name" : {
-            "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-activity.html#cfn-stepfunctions-activity-name",
-            "type" : [ "string", "object" ]
           }
         },
-        "required" : [ "Name" ],
         "additionalProperties" : false
       },
       "DependsOn" : {
@@ -29823,7 +35234,7 @@
         }
       }
     },
-    "required" : [ "Type", "Properties" ],
+    "required" : [ "Type" ],
     "additionalProperties" : false
   },
   "AWS_StepFunctions_StateMachine" : {
@@ -29831,9 +35242,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::StepFunctions::StateMachine",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html",
         "type" : "string",
         "enum" : [ "AWS::StepFunctions::StateMachine" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -29893,9 +35314,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-synthetics-canary.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Synthetics::Canary",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-synthetics-canary.html",
         "type" : "string",
         "enum" : [ "AWS::Synthetics::Canary" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -29967,9 +35398,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-transfer-server.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Transfer::Server",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-transfer-server.html",
         "type" : "string",
         "enum" : [ "AWS::Transfer::Server" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30034,9 +35475,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-transfer-user.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::Transfer::User",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-transfer-user.html",
         "type" : "string",
         "enum" : [ "AWS::Transfer::User" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30108,9 +35559,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-waf-bytematchset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAF::ByteMatchSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-waf-bytematchset.html",
         "type" : "string",
         "enum" : [ "AWS::WAF::ByteMatchSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30147,9 +35608,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-waf-ipset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAF::IPSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-waf-ipset.html",
         "type" : "string",
         "enum" : [ "AWS::WAF::IPSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30186,9 +35657,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-waf-rule.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAF::Rule",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-waf-rule.html",
         "type" : "string",
         "enum" : [ "AWS::WAF::Rule" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30229,9 +35710,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-waf-sizeconstraintset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAF::SizeConstraintSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-waf-sizeconstraintset.html",
         "type" : "string",
         "enum" : [ "AWS::WAF::SizeConstraintSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30268,9 +35759,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-waf-sqlinjectionmatchset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAF::SqlInjectionMatchSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-waf-sqlinjectionmatchset.html",
         "type" : "string",
         "enum" : [ "AWS::WAF::SqlInjectionMatchSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30307,9 +35808,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-waf-webacl.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAF::WebACL",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-waf-webacl.html",
         "type" : "string",
         "enum" : [ "AWS::WAF::WebACL" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30353,9 +35864,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-waf-xssmatchset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAF::XssMatchSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-waf-xssmatchset.html",
         "type" : "string",
         "enum" : [ "AWS::WAF::XssMatchSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30392,9 +35913,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-bytematchset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAFRegional::ByteMatchSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-bytematchset.html",
         "type" : "string",
         "enum" : [ "AWS::WAFRegional::ByteMatchSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30430,9 +35961,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-geomatchset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAFRegional::GeoMatchSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-geomatchset.html",
         "type" : "string",
         "enum" : [ "AWS::WAFRegional::GeoMatchSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30468,9 +36009,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-ipset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAFRegional::IPSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-ipset.html",
         "type" : "string",
         "enum" : [ "AWS::WAFRegional::IPSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30506,9 +36057,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-ratebasedrule.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAFRegional::RateBasedRule",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-ratebasedrule.html",
         "type" : "string",
         "enum" : [ "AWS::WAFRegional::RateBasedRule" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30556,9 +36117,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-regexpatternset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAFRegional::RegexPatternSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-regexpatternset.html",
         "type" : "string",
         "enum" : [ "AWS::WAFRegional::RegexPatternSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30594,9 +36165,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-rule.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAFRegional::Rule",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-rule.html",
         "type" : "string",
         "enum" : [ "AWS::WAFRegional::Rule" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30636,9 +36217,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-sizeconstraintset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAFRegional::SizeConstraintSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-sizeconstraintset.html",
         "type" : "string",
         "enum" : [ "AWS::WAFRegional::SizeConstraintSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30674,9 +36265,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-sqlinjectionmatchset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAFRegional::SqlInjectionMatchSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-sqlinjectionmatchset.html",
         "type" : "string",
         "enum" : [ "AWS::WAFRegional::SqlInjectionMatchSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30712,9 +36313,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-webacl.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAFRegional::WebACL",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-webacl.html",
         "type" : "string",
         "enum" : [ "AWS::WAFRegional::WebACL" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30757,9 +36368,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-webaclassociation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAFRegional::WebACLAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-webaclassociation.html",
         "type" : "string",
         "enum" : [ "AWS::WAFRegional::WebACLAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30791,9 +36412,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-xssmatchset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAFRegional::XssMatchSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-xssmatchset.html",
         "type" : "string",
         "enum" : [ "AWS::WAFRegional::XssMatchSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30829,9 +36460,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-ipset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAFv2::IPSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-ipset.html",
         "type" : "string",
         "enum" : [ "AWS::WAFv2::IPSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30887,9 +36528,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-regexpatternset.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAFv2::RegexPatternSet",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-regexpatternset.html",
         "type" : "string",
         "enum" : [ "AWS::WAFv2::RegexPatternSet" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -30941,9 +36592,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-rulegroup.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAFv2::RuleGroup",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-rulegroup.html",
         "type" : "string",
         "enum" : [ "AWS::WAFv2::RuleGroup" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -31002,9 +36663,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webacl.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAFv2::WebACL",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webacl.html",
         "type" : "string",
         "enum" : [ "AWS::WAFv2::WebACL" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -31062,9 +36733,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webaclassociation.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WAFv2::WebACLAssociation",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webaclassociation.html",
         "type" : "string",
         "enum" : [ "AWS::WAFv2::WebACLAssociation" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -31096,9 +36777,19 @@
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-workspaces-workspace.html",
     "properties" : {
       "Type" : {
-        "description" : "Type of resource equals only AWS::WorkSpaces::Workspace",
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-workspaces-workspace.html",
         "type" : "string",
         "enum" : [ "AWS::WorkSpaces::Workspace" ]
+      },
+      "DeletionPolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
+      },
+      "UpdateReplacePolicy" : {
+        "description" : "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html",
+        "type" : "string",
+        "enum" : [ "Delete", "Retain", "Snapshot" ]
       },
       "Properties" : {
         "type" : "object",
@@ -31647,6 +37338,10 @@
       },
       "EnableAutoBuild" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amplify-app-autobranchcreationconfig.html#cfn-amplify-app-autobranchcreationconfig-enableautobuild",
+        "type" : [ "boolean", "object" ]
+      },
+      "EnablePerformanceMode" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amplify-app-autobranchcreationconfig.html#cfn-amplify-app-autobranchcreationconfig-enableperformancemode",
         "type" : [ "boolean", "object" ]
       },
       "BuildSpec" : {
@@ -37383,6 +43078,14 @@
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties.html#cfn-batch-jobdefinition-containerproperties-user",
         "type" : [ "string", "object" ]
       },
+      "Secrets" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties.html#cfn-batch-jobdefinition-containerproperties-secrets",
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/definitions/AWS_Batch_JobDefinition_Secret"
+        },
+        "minItems" : 0
+      },
       "Memory" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties.html#cfn-batch-jobdefinition-containerproperties-memory",
         "type" : [ "integer", "object" ]
@@ -37418,6 +43121,9 @@
         },
         "minItems" : 0
       },
+      "LogConfiguration" : {
+        "$ref" : "#/definitions/AWS_Batch_JobDefinition_LogConfiguration"
+      },
       "MountPoints" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties.html#cfn-batch-jobdefinition-containerproperties-mountpoints",
         "type" : "array",
@@ -37425,6 +43131,10 @@
           "$ref" : "#/definitions/AWS_Batch_JobDefinition_MountPoints"
         },
         "minItems" : 0
+      },
+      "ExecutionRoleArn" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties.html#cfn-batch-jobdefinition-containerproperties-executionrolearn",
+        "type" : [ "string", "object" ]
       },
       "Volumes" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties.html#cfn-batch-jobdefinition-containerproperties-volumes",
@@ -37508,6 +43218,22 @@
     "type" : "object",
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties-linuxparameters.html",
     "properties" : {
+      "Swappiness" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties-linuxparameters.html#cfn-batch-jobdefinition-containerproperties-linuxparameters-swappiness",
+        "type" : [ "integer", "object" ]
+      },
+      "Tmpfs" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties-linuxparameters.html#cfn-batch-jobdefinition-containerproperties-linuxparameters-tmpfs",
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/definitions/AWS_Batch_JobDefinition_Tmpfs"
+        },
+        "minItems" : 0
+      },
+      "SharedMemorySize" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties-linuxparameters.html#cfn-batch-jobdefinition-containerproperties-linuxparameters-sharedmemorysize",
+        "type" : [ "integer", "object" ]
+      },
       "Devices" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties-linuxparameters.html#cfn-batch-jobdefinition-containerproperties-linuxparameters-devices",
         "type" : "array",
@@ -37515,8 +43241,40 @@
           "$ref" : "#/definitions/AWS_Batch_JobDefinition_Device"
         },
         "minItems" : 0
+      },
+      "InitProcessEnabled" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties-linuxparameters.html#cfn-batch-jobdefinition-containerproperties-linuxparameters-initprocessenabled",
+        "type" : [ "boolean", "object" ]
+      },
+      "MaxSwap" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties-linuxparameters.html#cfn-batch-jobdefinition-containerproperties-linuxparameters-maxswap",
+        "type" : [ "integer", "object" ]
       }
     },
+    "additionalProperties" : false
+  },
+  "AWS_Batch_JobDefinition_LogConfiguration" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties-logconfiguration.html",
+    "properties" : {
+      "SecretOptions" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties-logconfiguration.html#cfn-batch-jobdefinition-containerproperties-logconfiguration-secretoptions",
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/definitions/AWS_Batch_JobDefinition_Secret"
+        },
+        "minItems" : 0
+      },
+      "Options" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties-logconfiguration.html#cfn-batch-jobdefinition-containerproperties-logconfiguration-options",
+        "type" : [ "object" ]
+      },
+      "LogDriver" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties-logconfiguration.html#cfn-batch-jobdefinition-containerproperties-logconfiguration-logdriver",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "required" : [ "LogDriver" ],
     "additionalProperties" : false
   },
   "AWS_Batch_JobDefinition_MountPoints" : {
@@ -37603,6 +43361,22 @@
     },
     "additionalProperties" : false
   },
+  "AWS_Batch_JobDefinition_Secret" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-secret.html",
+    "properties" : {
+      "ValueFrom" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-secret.html#cfn-batch-jobdefinition-secret-valuefrom",
+        "type" : [ "string", "object" ]
+      },
+      "Name" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-secret.html#cfn-batch-jobdefinition-secret-name",
+        "type" : [ "string", "object" ]
+      }
+    },
+    "required" : [ "ValueFrom", "Name" ],
+    "additionalProperties" : false
+  },
   "AWS_Batch_JobDefinition_Timeout" : {
     "type" : "object",
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-timeout.html",
@@ -37612,6 +43386,30 @@
         "type" : [ "integer", "object" ]
       }
     },
+    "additionalProperties" : false
+  },
+  "AWS_Batch_JobDefinition_Tmpfs" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-tmpfs.html",
+    "properties" : {
+      "Size" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-tmpfs.html#cfn-batch-jobdefinition-tmpfs-size",
+        "type" : [ "integer", "object" ]
+      },
+      "ContainerPath" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-tmpfs.html#cfn-batch-jobdefinition-tmpfs-containerpath",
+        "type" : [ "string", "object" ]
+      },
+      "MountOptions" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-tmpfs.html#cfn-batch-jobdefinition-tmpfs-mountoptions",
+        "type" : "array",
+        "items" : {
+          "type" : [ "string", "object" ]
+        },
+        "minItems" : 0
+      }
+    },
+    "required" : [ "Size", "ContainerPath" ],
     "additionalProperties" : false
   },
   "AWS_Batch_JobDefinition_Ulimit" : {
@@ -38094,7 +43892,7 @@
         "$ref" : "#/definitions/AWS_CloudFront_CachePolicy_ParametersInCacheKeyAndForwardedToOrigin"
       }
     },
-    "required" : [ "MinTTL", "Name" ],
+    "required" : [ "DefaultTTL", "MaxTTL", "MinTTL", "Name" ],
     "additionalProperties" : false
   },
   "AWS_CloudFront_CachePolicy_CookiesConfig" : {
@@ -45483,6 +51281,17 @@
       },
       "Provider" : {
         "$ref" : "#/definitions/AWS_EKS_Cluster_Provider"
+      }
+    },
+    "additionalProperties" : false
+  },
+  "AWS_EKS_Cluster_KubernetesNetworkConfig" : {
+    "type" : "object",
+    "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-kubernetesnetworkconfig.html",
+    "properties" : {
+      "ServiceIpv4Cidr" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-kubernetesnetworkconfig.html#cfn-eks-cluster-kubernetesnetworkconfig-serviceipv4cidr",
+        "type" : [ "string", "object" ]
       }
     },
     "additionalProperties" : false
@@ -64787,16 +70596,16 @@
     "type" : "object",
     "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-activity-tagsentry.html",
     "properties" : {
-      "Value" : {
-        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-activity-tagsentry.html#cfn-stepfunctions-activity-tagsentry-value",
-        "type" : [ "string", "object" ]
-      },
       "Key" : {
         "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-activity-tagsentry.html#cfn-stepfunctions-activity-tagsentry-key",
         "type" : [ "string", "object" ]
+      },
+      "Value" : {
+        "description" : "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-activity-tagsentry.html#cfn-stepfunctions-activity-tagsentry-value",
+        "type" : [ "string", "object" ]
       }
     },
-    "required" : [ "Value", "Key" ],
+    "required" : [ "Key", "Value" ],
     "additionalProperties" : false
   },
   "AWS_StepFunctions_StateMachine_CloudWatchLogsLogGroup" : {
@@ -67962,9 +73771,17 @@
     "Resources": {
       "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html",
       "$ref": "#/definitions/resources"
+    },
+    "Hooks": {
+      "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/blue-green.html",
+      "type": "object"
+    },
+    "Rules": {
+      "description": "https://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html",
+      "type": "object"
     }
   },
-  "description": "CFN JSON specification generated from version 18.4.0",
+  "description": "CFN JSON specification generated from version 18.5.0",
   "required": [
     "Resources"
   ]


### PR DESCRIPTION
https://github.com/aws-cloudformation/aws-cloudformation-template-schema/issues/32

https://github.com/aws-cloudformation/aws-cloudformation-template-schema/blob/master/docs/tool/instructions.md

as described in https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code/pull/76

---

running into https://github.com/awslabs/goformation/issues/300 still

---

**Template Schema improvements:**
[DeletionPolicy and UpdateReplacePolicy support](https://github.com/aws-cloudformation/aws-cloudformation-template-schema/pull/46)
[more AWS hosted transforms and Hooks and Rules template sections](https://github.com/aws-cloudformation/aws-cloudformation-template-schema/pull/47)
[linking resource type reference documentation on Type as well as logical ID](https://github.com/aws-cloudformation/aws-cloudformation-template-schema/pull/48)