### PR TITLE
automating CloudFormation Template Schema upgrades with Github actions

### DIFF
--- a/.github/workflows/template-schema-updater.yaml
+++ b/.github/workflows/template-schema-updater.yaml
@@ -1,0 +1,10 @@
+on:
+ schedule: 
+  - cron: '* * * * *'
+jobs:
+  job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: touch hello-world.txt
+      - uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/template-schema-updater.yaml
+++ b/.github/workflows/template-schema-updater.yaml
@@ -1,10 +1,38 @@
 on:
- schedule: 
-  - cron: '*/5 * * * *'
+  schedule:
+    - cron: '*/5 * * * *'
 jobs:
   job:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: touch hello-world.txt
+      - uses: actions/checkout@v2
+        with:
+          repository: aws-cloudformation/aws-cloudformation-template-schema
+          path: aws-cloudformation-template-schema
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - run: |
+          cd aws-cloudformation-template-schema
+          mvn package
+          echo 'settings:
+            regions: [us-east-1]
+            output: out' > cfg.yml
+          java -jar target/aws-cloudformation-template-schema-1.0-SNAPSHOT-jar-with-dependencies.jar --config-file cfg.yml
+          mv out/us-east-1/all-spec.json ../schema/all-spec.json
+          cd ..
+          rm -rf aws-cloudformation-template-schema
       - uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: |
+            CloudFormation Template Schema upgrade
+            https://github.com/aws-cloudformation/aws-cloudformation-template-schema/issues/32
+            https://github.com/aws-cloudformation/aws-cloudformation-template-schema/blob/master/docs/tool/instructions.md
+            as described in https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code/pull/76
+          delete-branch: true
+          title: CloudFormation Template Schema upgrade
+          body: |
+            https://github.com/aws-cloudformation/aws-cloudformation-template-schema/issues/32
+            https://github.com/aws-cloudformation/aws-cloudformation-template-schema/blob/master/docs/tool/instructions.md
+            as described in https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code/pull/76

--- a/.github/workflows/template-schema-updater.yaml
+++ b/.github/workflows/template-schema-updater.yaml
@@ -1,6 +1,6 @@
 on:
  schedule: 
-  - cron: '* * * * *'
+  - cron: '*/5 * * * *'
 jobs:
   job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
as described in https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code/pull/76

---

[`GitHub Actions usage is free for public repositories`](https://docs.github.com/en/free-pro-team@latest/github/setting-up-and-managing-billing-and-payments-on-github/about-billing-for-github-actions)

[`Shortest interval you can run scheduled workflows is once every 5 minutes`](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#onschedule) ([`takes while before schedules actions run at all in a new repo`](https://github.community/t/schedule-workflows-missing/17653/4))

[`Checkout multiple repos`](https://github.com/actions/checkout#Checkout-multiple-repos-nested)
[`Building and testing Java with Maven`](https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-java-with-maven)
[`peter-evans/create-pull-request`](https://github.com/peter-evans/create-pull-request#usage)

tested in my fork since I wasn't sure how to test in this repo without pushing