### PR TITLE
switch vsce to run with npm run

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,6 +20,6 @@ jobs:
         npm run compile
     - name: Publish
       if: success()
-      run: vsce publish
+      run: npm run deploy
       env:
         VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
         "compile:server": "tsc -p ./server/tsconfig.json",
         "watch:server": "tsc -w -p ./server/tsconfig.json",
         "test": "node ./client/out/test/runTest.js",
-        "lint": "eslint -c .eslintrc.js --ext .ts server/ && eslint -c .eslintrc.js --ext .ts client/"
+        "lint": "eslint -c .eslintrc.js --ext .ts server/ && eslint -c .eslintrc.js --ext .ts client/",
+        "deploy": "vsce publish"
     },
     "devDependencies": {
         "@types/mocha": "^2.2.42",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- move vsce to the github action and not the package.json

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
