### PR TITLE
Remove issue link in automated pr

### DIFF
--- a/.github/workflows/template-schema-updater.yaml
+++ b/.github/workflows/template-schema-updater.yaml
@@ -38,5 +38,5 @@ jobs:
             https://github.com/aws-cloudformation/aws-cloudformation-template-schema/blob/master/docs/tool/instructions.md
             as described in https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code/pull/76
 
-            If tests are stuck on https://github.com/peter-evans/create-pull-request/issues/48:
+            If tests are stuck:
             ["Manually close pull requests and immediately reopen them. This will enable `on: pull_request` workflows to run and be added as checks."](https://github.com/peter-evans/create-pull-request/blob/master/docs/concepts-guidelines.md#triggering-further-workflow-runs)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I noticed that [this issue](https://github.com/peter-evans/create-pull-request/issues/48) is picking up lots of mentions because it's linked from the automated PRs in this repository. Would you mind if we remove the link to reduce the noise?

Hope you are finding `create-pull-request` action useful. 👍 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
